### PR TITLE
feat(diff-mode): implement interactive diff/compare

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -73,6 +73,8 @@
 - [ ] Config-parity, make sure everything works.
 - [ ] Hot reloading of config (I can edit the config on the fly and the config is still read without restarting lazygit)
 - [x] Bug: in the diff exploration view, because of the 10s interval I think the position of which I scrolled at also seems to get reset. Ideally not. Just like how the [new] and [old] -- it used to have this bug but I fixed it.
+- [ ] Search feature inside the diff exploration view is much needed. Grep for all in diff_mode is good too.
+- [ ] In `?` help dialog, use tui-textarea so I can erase the input using opt-backspace.
 
 ## Stuff I wanna do differently
 
@@ -84,7 +86,7 @@
       - The node-like colors w/ indicators on the left side are great to have.
       - I can SEE the commit it'll rebase ontop of i.e. 'Hello GitLens' in this example.
       - I can see a 'Start Rebase' and an 'Abort' action.
-- [ ] Diff Mode / Compare Mode
+- [x] Diff Mode / Compare Mode
   - Diff mode can be opened w/ a commad palette or when focusing on either BRANCH or COMMITS tab.
   - First trigger of it opening will open its own sort of screen that looks like:
 

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -204,6 +204,47 @@ impl GitCommands {
         }
     }
 
+    /// Get the list of files changed between two refs (for diff/compare mode).
+    pub fn diff_refs_files(&self, ref_a: &str, ref_b: &str) -> Result<Vec<crate::model::CommitFile>> {
+        let result = self
+            .git()
+            .args(&["diff", "--name-status", ref_a, ref_b])
+            .run_expecting_success()?;
+
+        let mut files = Vec::new();
+        for line in result.stdout.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let mut parts = line.splitn(2, '\t');
+            let status_str = parts.next().unwrap_or("");
+            let name = parts.next().unwrap_or("").to_string();
+            if name.is_empty() {
+                continue;
+            }
+            let status = match status_str.chars().next() {
+                Some('A') => crate::model::FileChangeStatus::Added,
+                Some('D') => crate::model::FileChangeStatus::Deleted,
+                Some('R') => crate::model::FileChangeStatus::Renamed,
+                Some('C') => crate::model::FileChangeStatus::Copied,
+                Some('U') => crate::model::FileChangeStatus::Unmerged,
+                _ => crate::model::FileChangeStatus::Modified,
+            };
+            files.push(crate::model::CommitFile { name, status });
+        }
+        Ok(files)
+    }
+
+    /// Get the diff of a single file between two refs (for diff/compare mode).
+    pub fn diff_refs_file(&self, ref_a: &str, ref_b: &str, path: &str) -> Result<String> {
+        let result = self
+            .git()
+            .args(&["diff", "--color=never", ref_a, ref_b, "--", path])
+            .run_expecting_success()?;
+        Ok(result.stdout)
+    }
+
     /// Get the staged content of a file.
     pub fn file_content_staged(&self, path: &str) -> Result<String> {
         let result = self

--- a/src/gui/controller/diff_mode.rs
+++ b/src/gui/controller/diff_mode.rs
@@ -1,0 +1,393 @@
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::config::keybindings::parse_key;
+use crate::gui::Gui;
+use crate::gui::modes::diff_mode::{DiffModeFocus, DiffModeSelector};
+use crate::gui::popup::{HelpEntry, HelpSection, PopupState};
+
+pub fn handle_key(gui: &mut Gui, key: KeyEvent) -> Result<()> {
+    // Popup takes priority (for ? help)
+    if gui.popup != PopupState::None {
+        return gui.handle_popup_key(key);
+    }
+
+    // If editing a combobox, route to combobox input handler
+    if gui.diff_mode.editing.is_some() {
+        return handle_combobox_key(gui, key);
+    }
+
+    // q to exit diff mode
+    if key.code == KeyCode::Char('q') {
+        gui.diff_mode.exit();
+        return Ok(());
+    }
+
+    // ? to show help
+    if key.code == KeyCode::Char('?') {
+        show_diff_mode_help(gui);
+        return Ok(());
+    }
+
+    // Tab to cycle focus
+    if key.code == KeyCode::Tab {
+        gui.diff_mode.focus = gui.diff_mode.focus.next();
+        gui.needs_diff_refresh = true;
+        return Ok(());
+    }
+
+    // Number keys 1-4 to jump to focus panel
+    if let KeyCode::Char(c @ '1'..='4') = key.code {
+        if let Some(focus) = DiffModeFocus::from_number(c.to_digit(10).unwrap()) {
+            gui.diff_mode.focus = focus;
+            gui.needs_diff_refresh = true;
+            return Ok(());
+        }
+    }
+
+    // Ctrl+S to swap refs
+    if key.code == KeyCode::Char('s') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        gui.diff_mode.swap_refs();
+        if gui.diff_mode.has_both_refs() {
+            reload_diff_files(gui)?;
+        }
+        gui.needs_diff_refresh = true;
+        return Ok(());
+    }
+
+    // Focus-specific keys
+    match gui.diff_mode.focus {
+        DiffModeFocus::SelectorA => {
+            if key.code == KeyCode::Enter {
+                gui.diff_mode.start_editing(DiffModeSelector::A);
+                let model = gui.model.lock().unwrap();
+                gui.diff_mode.search_refs(&model.branches, &model.tags, &model.commits, &model.remotes);
+            }
+        }
+        DiffModeFocus::SelectorB => {
+            if key.code == KeyCode::Enter {
+                gui.diff_mode.start_editing(DiffModeSelector::B);
+                let model = gui.model.lock().unwrap();
+                gui.diff_mode.search_refs(&model.branches, &model.tags, &model.commits, &model.remotes);
+            }
+        }
+        DiffModeFocus::CommitFiles => {
+            handle_commit_files_key(gui, key)?;
+        }
+        DiffModeFocus::DiffExploration => {
+            handle_diff_exploration_key(gui, key)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_combobox_key(gui: &mut Gui, key: KeyEvent) -> Result<()> {
+    match key.code {
+        KeyCode::Esc => {
+            gui.diff_mode.cancel_editing();
+        }
+        KeyCode::Enter => {
+            gui.diff_mode.confirm_selection();
+            if gui.diff_mode.has_both_refs() {
+                reload_diff_files(gui)?;
+                // Both refs set — auto-focus commit files
+                gui.diff_mode.focus = DiffModeFocus::CommitFiles;
+            } else if gui.diff_mode.ref_a.is_empty() {
+                // B was just set, A still empty — jump to A and start editing
+                gui.diff_mode.focus = DiffModeFocus::SelectorA;
+                gui.diff_mode.start_editing(DiffModeSelector::A);
+                let model = gui.model.lock().unwrap();
+                gui.diff_mode.search_refs(&model.branches, &model.tags, &model.commits, &model.remotes);
+            } else {
+                // A was just set, B still empty — jump to B and start editing
+                gui.diff_mode.focus = DiffModeFocus::SelectorB;
+                gui.diff_mode.start_editing(DiffModeSelector::B);
+                let model = gui.model.lock().unwrap();
+                gui.diff_mode.search_refs(&model.branches, &model.tags, &model.commits, &model.remotes);
+            }
+            gui.needs_diff_refresh = true;
+        }
+        KeyCode::Up => {
+            if gui.diff_mode.search_selected > 0 {
+                gui.diff_mode.search_selected -= 1;
+                gui.diff_mode.ensure_dropdown_visible(10);
+            }
+        }
+        KeyCode::Down => {
+            let len = gui.diff_mode.search_results.len();
+            if len > 0 && gui.diff_mode.search_selected < len - 1 {
+                gui.diff_mode.search_selected += 1;
+                gui.diff_mode.ensure_dropdown_visible(10);
+            }
+        }
+        _ => {
+            // Forward all other keys to the textarea (handles Backspace, Opt+Backspace, etc.)
+            if let Some(ref mut ta) = gui.diff_mode.textarea {
+                ta.input(key);
+            }
+            // Re-search after any text change
+            let model = gui.model.lock().unwrap();
+            gui.diff_mode.search_refs(&model.branches, &model.tags, &model.commits, &model.remotes);
+        }
+    }
+    Ok(())
+}
+
+fn handle_commit_files_key(gui: &mut Gui, key: KeyEvent) -> Result<()> {
+    let keybindings = &gui.config.user_config.keybinding;
+
+    // Toggle tree view (backtick)
+    if matches_key(key, &keybindings.files.toggle_tree_view) {
+        gui.diff_mode.show_tree = !gui.diff_mode.show_tree;
+        update_diff_mode_tree(gui);
+        gui.diff_mode.diff_files_selected = 0;
+        return Ok(());
+    }
+
+    let len = gui.diff_mode.visible_files_len();
+    if len == 0 {
+        return Ok(());
+    }
+
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            if gui.diff_mode.diff_files_selected < len - 1 {
+                gui.diff_mode.diff_files_selected += 1;
+                gui.needs_diff_refresh = true;
+            }
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            if gui.diff_mode.diff_files_selected > 0 {
+                gui.diff_mode.diff_files_selected -= 1;
+                gui.needs_diff_refresh = true;
+            }
+        }
+        KeyCode::Enter => {
+            if gui.diff_mode.show_tree {
+                // Toggle dir collapse or focus diff
+                if let Some(node) = gui.diff_mode.tree_nodes.get(gui.diff_mode.diff_files_selected) {
+                    if node.is_dir {
+                        let path = node.path.clone();
+                        if gui.diff_mode.collapsed_dirs.contains(&path) {
+                            gui.diff_mode.collapsed_dirs.remove(&path);
+                        } else {
+                            gui.diff_mode.collapsed_dirs.insert(path);
+                        }
+                        update_diff_mode_tree(gui);
+                        return Ok(());
+                    }
+                }
+            }
+            gui.diff_mode.focus = DiffModeFocus::DiffExploration;
+            gui.needs_diff_refresh = true;
+        }
+        KeyCode::Char('g') => {
+            gui.diff_mode.diff_files_selected = 0;
+            gui.needs_diff_refresh = true;
+        }
+        KeyCode::Char('G') => {
+            gui.diff_mode.diff_files_selected = len.saturating_sub(1);
+            gui.needs_diff_refresh = true;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn handle_diff_exploration_key(gui: &mut Gui, key: KeyEvent) -> Result<()> {
+    // Handle text selection keys first (y to copy, Esc to dismiss)
+    if gui.diff_view.selection.is_some() {
+        match key.code {
+            KeyCode::Char('y') => {
+                let text = gui.diff_view.selection.as_ref().unwrap().text.clone();
+                gui.diff_view.selection = None;
+                if !text.is_empty() {
+                    crate::os::platform::Platform::copy_to_clipboard(&text)?;
+                }
+                return Ok(());
+            }
+            KeyCode::Esc => {
+                gui.diff_view.selection = None;
+                return Ok(());
+            }
+            _ => {
+                gui.diff_view.selection = None;
+            }
+        }
+    }
+
+    match key.code {
+        KeyCode::Esc => {
+            gui.diff_mode.focus = DiffModeFocus::CommitFiles;
+        }
+        KeyCode::Char('j') | KeyCode::Down => {
+            gui.diff_view.scroll_down(1);
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            gui.diff_view.scroll_up(1);
+        }
+        KeyCode::Char('h') | KeyCode::Left => {
+            gui.diff_view.scroll_left(4);
+        }
+        KeyCode::Char('l') | KeyCode::Right => {
+            gui.diff_view.scroll_right(4);
+        }
+        KeyCode::Char('}') => {
+            gui.diff_view.next_hunk();
+        }
+        KeyCode::Char('{') => {
+            gui.diff_view.prev_hunk();
+        }
+        KeyCode::Char(']') => {
+            use crate::pager::side_by_side::DiffSideView;
+            gui.diff_view.side_view = match gui.diff_view.side_view {
+                DiffSideView::NewOnly => DiffSideView::Both,
+                _ => DiffSideView::NewOnly,
+            };
+        }
+        KeyCode::Char('[') => {
+            use crate::pager::side_by_side::DiffSideView;
+            gui.diff_view.side_view = match gui.diff_view.side_view {
+                DiffSideView::OldOnly => DiffSideView::Both,
+                _ => DiffSideView::OldOnly,
+            };
+        }
+        KeyCode::PageDown => {
+            gui.diff_view.scroll_down(20);
+        }
+        KeyCode::PageUp => {
+            gui.diff_view.scroll_up(20);
+        }
+        KeyCode::Char('g') => {
+            gui.diff_view.scroll_offset = 0;
+        }
+        KeyCode::Char('G') => {
+            let max = gui.diff_view.lines.len().saturating_sub(1);
+            gui.diff_view.scroll_offset = max;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Reload the file list for the current A..B diff.
+pub fn reload_diff_files(gui: &mut Gui) -> Result<()> {
+    let ref_a = gui.diff_mode.ref_a.clone();
+    let ref_b = gui.diff_mode.ref_b.clone();
+    if ref_a.is_empty() || ref_b.is_empty() {
+        return Ok(());
+    }
+    // Clear the diff view since we're loading new files
+    gui.diff_view = crate::pager::side_by_side::DiffViewState::new();
+
+    match gui.git.diff_refs_files(&ref_a, &ref_b) {
+        Ok(files) => {
+            gui.diff_mode.diff_files = files;
+            gui.diff_mode.diff_files_selected = 0;
+            gui.diff_mode.diff_files_scroll = 0;
+            if gui.diff_mode.show_tree {
+                update_diff_mode_tree(gui);
+            }
+        }
+        Err(e) => {
+            gui.diff_mode.diff_files.clear();
+            gui.popup = PopupState::Message {
+                title: "Diff error".to_string(),
+                message: format!("{}", e),
+                kind: crate::gui::popup::MessageKind::Error,
+            };
+        }
+    }
+    Ok(())
+}
+
+fn update_diff_mode_tree(gui: &mut Gui) {
+    if gui.diff_mode.show_tree {
+        gui.diff_mode.tree_nodes = crate::model::file_tree::build_commit_file_tree(
+            &gui.diff_mode.diff_files,
+            &gui.diff_mode.collapsed_dirs,
+        );
+    } else {
+        gui.diff_mode.tree_nodes.clear();
+    }
+}
+
+/// Called from the main loop to request diff loading for the currently selected file in diff mode.
+pub fn maybe_request_diff(gui: &mut Gui) {
+    if !gui.diff_mode.has_both_refs() || gui.diff_mode.diff_files.is_empty() {
+        return;
+    }
+
+    // Resolve file index (tree view maps node -> file index)
+    let selected = gui.diff_mode.diff_files_selected;
+    let file_idx = if gui.diff_mode.show_tree {
+        gui.diff_mode.tree_nodes.get(selected).and_then(|n| n.file_index)
+    } else {
+        Some(selected)
+    };
+
+    let Some(idx) = file_idx else { return };
+    let Some(file) = gui.diff_mode.diff_files.get(idx) else { return };
+
+    let name = file.name.clone();
+    let ref_a = gui.diff_mode.ref_a.clone();
+    let ref_b = gui.diff_mode.ref_b.clone();
+
+    match gui.git.diff_refs_file(&ref_a, &ref_b, &name) {
+        Ok(diff) => {
+            if diff.is_empty() {
+                gui.diff_view = crate::pager::side_by_side::DiffViewState::new();
+            } else {
+                gui.diff_view.load_from_diff_output(&name, &diff);
+            }
+        }
+        Err(_) => {
+            gui.diff_view = crate::pager::side_by_side::DiffViewState::new();
+        }
+    }
+}
+
+fn show_diff_mode_help(gui: &mut Gui) {
+    let diff_mode_section = HelpSection {
+        title: "Compare / Diff Mode".into(),
+        entries: vec![
+            HelpEntry { key: "q".into(), description: "Exit diff mode".into() },
+            HelpEntry { key: "Tab".into(), description: "Cycle focus (A → B → Files → Diff)".into() },
+            HelpEntry { key: "1-4".into(), description: "Jump to panel".into() },
+            HelpEntry { key: "<c-s>".into(), description: "Swap A and B".into() },
+            HelpEntry { key: "<enter>".into(), description: "Edit selector / Focus diff".into() },
+            HelpEntry { key: "`".into(), description: "Toggle file tree view".into() },
+            HelpEntry { key: "j/k".into(), description: "Navigate files / Scroll diff".into() },
+            HelpEntry { key: "{/}".into(), description: "Previous / next hunk".into() },
+            HelpEntry { key: "[/]".into(), description: "Toggle old / new only view".into() },
+            HelpEntry { key: "g/G".into(), description: "Go to top / bottom".into() },
+            HelpEntry { key: "?".into(), description: "Show this help".into() },
+        ],
+    };
+
+    let combobox_section = HelpSection {
+        title: "Combobox (while editing A or B)".into(),
+        entries: vec![
+            HelpEntry { key: "<enter>".into(), description: "Confirm selection".into() },
+            HelpEntry { key: "<esc>".into(), description: "Cancel".into() },
+            HelpEntry { key: "Up/Down".into(), description: "Navigate results".into() },
+            HelpEntry { key: "Type".into(), description: "Filter branches, tags, commits, remotes".into() },
+        ],
+    };
+
+    gui.popup = PopupState::Help {
+        sections: vec![diff_mode_section, combobox_section],
+        selected: 0,
+        search: String::new(),
+        scroll_offset: 0,
+    };
+}
+
+fn matches_key(key: KeyEvent, binding: &str) -> bool {
+    if let Some(expected) = parse_key(binding) {
+        key.code == expected.code && key.modifiers == expected.modifiers
+    } else {
+        false
+    }
+}

--- a/src/gui/controller/mod.rs
+++ b/src/gui/controller/mod.rs
@@ -4,6 +4,7 @@ pub mod branches;
 pub mod commit_files;
 pub mod commits;
 pub mod custom_commands;
+pub mod diff_mode;
 pub mod files;
 pub mod patch_building;
 pub mod reflog;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -29,6 +29,7 @@ use crate::pager::side_by_side::{DiffPanel, DiffPanelLayout, DiffViewState, Text
 use self::context::{ContextId, ContextManager, SideWindow};
 use self::layout::LayoutState;
 use self::popup::{HelpEntry, HelpSection};
+use self::modes::diff_mode::DiffModeState;
 use self::modes::patch_building::PatchBuildingState;
 use self::popup::{MessageKind, PopupState};
 
@@ -101,6 +102,8 @@ pub struct Gui {
     undo_reflog_idx: usize,
     /// Patch building mode state.
     pub patch_building: PatchBuildingState,
+    /// Diff/compare mode state.
+    pub diff_mode: DiffModeState,
     /// Stashed commit editor popup while commit menu or AI generation is shown.
     pending_commit_popup: Option<PopupState>,
     /// Search bar textarea (1-line editor for search input).
@@ -204,6 +207,7 @@ impl Gui {
             remote_op_tx,
             undo_reflog_idx: 0,
             patch_building: PatchBuildingState::new(),
+            diff_mode: DiffModeState::new(),
             pending_commit_popup: None,
             search_textarea: None,
             last_refresh_at: Instant::now(),
@@ -304,48 +308,62 @@ impl Gui {
 
             // Render
             terminal.draw(|frame| {
-                let model = self.model.lock().unwrap();
-                let search_state = if self.search_active || !self.search_query.is_empty() {
-                    Some((
-                        self.search_query.as_str(),
-                        self.search_matches.len(),
-                        self.search_match_idx,
-                    ))
+                if self.diff_mode.active {
+                    let theme = self.config.user_config.theme();
+                    presentation::diff_mode::render(
+                        frame,
+                        &self.diff_mode,
+                        &mut self.diff_view,
+                        &theme,
+                    );
+                    // Render popup overlay on top of diff mode (for ? help, errors, etc.)
+                    if self.popup != PopupState::None {
+                        views::render_popup(frame, &self.popup, frame.area(), self.spinner_frame);
+                    }
                 } else {
-                    None
-                };
-                let cmd_log = self.command_log.lock().unwrap();
-                views::render(
-                    frame,
-                    &model,
-                    &self.context_mgr,
-                    &self.layout,
-                    &self.popup,
-                    &self.config,
-                    &mut self.diff_view,
-                    self.screen_mode,
-                    self.show_file_tree,
-                    &self.file_tree_nodes,
-                    &self.collapsed_dirs,
-                    self.diff_focused,
-                    search_state,
-                    self.search_textarea.as_ref(),
-                    &cmd_log,
-                    self.show_command_log,
-                    &self.commit_branch_filter,
-                    self.show_commit_file_tree,
-                    &self.commit_file_tree_nodes,
-                    &self.commit_files_collapsed_dirs,
-                    &self.commit_files_hash,
-                    &self.commit_files_message,
-                    &self.branch_commits_name,
-                    &self.remote_branches_name,
-                    self.spinner_frame,
-                    self.remote_op_label.as_deref(),
-                    self.remote_op_success_at
-                        .map(|t| t.elapsed() < std::time::Duration::from_secs(5))
-                        .unwrap_or(false),
-                );
+                    let model = self.model.lock().unwrap();
+                    let search_state = if self.search_active || !self.search_query.is_empty() {
+                        Some((
+                            self.search_query.as_str(),
+                            self.search_matches.len(),
+                            self.search_match_idx,
+                        ))
+                    } else {
+                        None
+                    };
+                    let cmd_log = self.command_log.lock().unwrap();
+                    views::render(
+                        frame,
+                        &model,
+                        &self.context_mgr,
+                        &self.layout,
+                        &self.popup,
+                        &self.config,
+                        &mut self.diff_view,
+                        self.screen_mode,
+                        self.show_file_tree,
+                        &self.file_tree_nodes,
+                        &self.collapsed_dirs,
+                        self.diff_focused,
+                        search_state,
+                        self.search_textarea.as_ref(),
+                        &cmd_log,
+                        self.show_command_log,
+                        &self.commit_branch_filter,
+                        self.show_commit_file_tree,
+                        &self.commit_file_tree_nodes,
+                        &self.commit_files_collapsed_dirs,
+                        &self.commit_files_hash,
+                        &self.commit_files_message,
+                        &self.branch_commits_name,
+                        &self.remote_branches_name,
+                        self.spinner_frame,
+                        self.remote_op_label.as_deref(),
+                        self.remote_op_success_at
+                            .map(|t| t.elapsed() < std::time::Duration::from_secs(5))
+                            .unwrap_or(false),
+                    );
+                }
             })?;
 
             // Handle events
@@ -530,6 +548,18 @@ impl Gui {
 
     /// Request diff loading on a background thread if selection changed.
     fn maybe_request_diff(&mut self) {
+        // Diff mode has its own diff loading
+        if self.diff_mode.active {
+            let diff_key = format!("diffmode:{}", self.diff_mode.diff_files_selected);
+            if diff_key == self.last_diff_key && !self.needs_diff_refresh {
+                return;
+            }
+            self.last_diff_key = diff_key;
+            self.needs_diff_refresh = false;
+            controller::diff_mode::maybe_request_diff(self);
+            return;
+        }
+
         let active = self.context_mgr.active();
         let selected = self.context_mgr.selected_active();
         let diff_key = format!("{:?}:{}", active, selected);
@@ -767,6 +797,11 @@ impl Gui {
             return self.handle_search_key(key);
         }
 
+        // Diff mode takes priority over normal UI
+        if self.diff_mode.active {
+            return controller::diff_mode::handle_key(self, key);
+        }
+
         let keybindings = &self.config.user_config.keybinding;
 
         // When diff panel is focused, handle diff-specific keys
@@ -941,6 +976,13 @@ impl Gui {
         }
         if matches_key(key, &keybindings.universal.prev_screen_mode) {
             self.prev_screen_mode();
+            return Ok(());
+        }
+
+        // Diff/Compare mode (W)
+        if key.code == KeyCode::Char('W') {
+            self.diff_mode.enter();
+            self.diff_view = DiffViewState::new();
             return Ok(());
         }
 
@@ -1189,7 +1231,7 @@ impl Gui {
         Ok(())
     }
 
-    fn handle_popup_key(&mut self, key: KeyEvent) -> Result<()> {
+    pub(crate) fn handle_popup_key(&mut self, key: KeyEvent) -> Result<()> {
         match &self.popup {
             PopupState::Confirm { .. } => {
                 if key.code == KeyCode::Char('y') || key.code == KeyCode::Enter {
@@ -1565,6 +1607,7 @@ impl Gui {
                 HelpEntry { key: "{/}".into(), description: "Previous/next hunk".into() },
                 HelpEntry { key: "[/]".into(), description: "Toggle old/new only view".into() },
                 HelpEntry { key: ";".into(), description: "Toggle command log".into() },
+                HelpEntry { key: "W".into(), description: "Compare / Diff mode".into() },
                 HelpEntry { key: "1-5".into(), description: "Jump to panel".into() },
                 HelpEntry { key: "?".into(), description: "Show this help".into() },
             ],
@@ -2242,6 +2285,12 @@ impl Gui {
             return;
         }
 
+        // Diff mode has its own mouse handling
+        if self.diff_mode.active {
+            self.handle_diff_mode_mouse(mouse);
+            return;
+        }
+
         // Help popup intercepts mouse scroll
         if let PopupState::Help { sections, scroll_offset, search, .. } = &mut self.popup {
             // Compute total display rows so we can clamp scroll
@@ -2364,6 +2413,180 @@ impl Gui {
             }
             MouseEventKind::ScrollRight => {
                 if self.diff_focused || self.is_in_main_panel(mouse.column) {
+                    self.diff_view.scroll_right(4);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_diff_mode_mouse(&mut self, mouse: MouseEvent) {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEventKind};
+        use ratatui::layout::{Constraint, Direction, Layout, Rect};
+        use self::modes::diff_mode::DiffModeFocus;
+
+        // Help popup intercepts mouse scroll
+        if let PopupState::Help { sections, scroll_offset, search, .. } = &mut self.popup {
+            let search_lower = search.to_lowercase();
+            let has_search = !search_lower.is_empty();
+            let total_rows: usize = sections.iter().map(|s| {
+                let visible = if has_search {
+                    s.entries.iter().filter(|e| {
+                        e.key.to_lowercase().contains(&search_lower)
+                            || e.description.to_lowercase().contains(&search_lower)
+                    }).count()
+                } else {
+                    s.entries.len()
+                };
+                if visible > 0 { visible + 1 } else { 0 }
+            }).sum();
+
+            match mouse.kind {
+                MouseEventKind::ScrollUp => { *scroll_offset = scroll_offset.saturating_sub(3); }
+                MouseEventKind::ScrollDown => { *scroll_offset = (*scroll_offset + 3).min(total_rows.saturating_sub(1)); }
+                _ => {}
+            }
+            return;
+        }
+
+        let area = Rect::new(0, 0, self.layout.width, self.layout.height);
+
+        // Replicate the diff mode layout to determine regions
+        let outer = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(area);
+
+        let content = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(33), Constraint::Percentage(67)])
+            .split(outer[0]);
+
+        let sidebar = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3),
+                Constraint::Length(3),
+                Constraint::Min(1),
+            ])
+            .split(content[0]);
+
+        let selector_a_rect = sidebar[0];
+        let selector_b_rect = sidebar[1];
+        let files_rect = sidebar[2];
+        let diff_rect = content[1];
+
+        let col = mouse.column;
+        let row = mouse.row;
+
+        match mouse.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                // Check if click is in the diff panel — start text selection
+                if rect_contains(diff_rect, col, row) && !self.diff_view.is_empty() {
+                    let pl = DiffPanelLayout::compute(diff_rect, &self.diff_view);
+                    if let Some(panel) = pl.panel_at_x(col) {
+                        self.diff_view.selection = Some(TextSelection {
+                            panel,
+                            start_col: col,
+                            start_row: row,
+                            end_col: col,
+                            end_row: row,
+                            dragging: true,
+                            text: String::new(),
+                        });
+                    } else {
+                        self.diff_view.selection = None;
+                    }
+                    self.diff_mode.focus = DiffModeFocus::DiffExploration;
+                } else {
+                    self.diff_view.selection = None;
+
+                    // Click on panels to switch focus
+                    if rect_contains(selector_a_rect, col, row) {
+                        self.diff_mode.focus = DiffModeFocus::SelectorA;
+                    } else if rect_contains(selector_b_rect, col, row) {
+                        self.diff_mode.focus = DiffModeFocus::SelectorB;
+                    } else if rect_contains(files_rect, col, row) {
+                        self.diff_mode.focus = DiffModeFocus::CommitFiles;
+                        // Click to select a file
+                        let inner_y = row.saturating_sub(files_rect.y + 1);
+                        let len = self.diff_mode.visible_files_len();
+                        let visible_height = files_rect.height.saturating_sub(2) as usize;
+                        let scroll_offset = if self.diff_mode.diff_files_selected >= visible_height {
+                            self.diff_mode.diff_files_selected - visible_height + 1
+                        } else {
+                            0
+                        };
+                        let clicked_idx = scroll_offset + inner_y as usize;
+                        if clicked_idx < len {
+                            self.diff_mode.diff_files_selected = clicked_idx;
+                            self.needs_diff_refresh = true;
+                        }
+                    } else if rect_contains(diff_rect, col, row) {
+                        self.diff_mode.focus = DiffModeFocus::DiffExploration;
+                    }
+                }
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                let pl = DiffPanelLayout::compute(diff_rect, &self.diff_view);
+                if let Some(ref mut sel) = self.diff_view.selection {
+                    if sel.dragging {
+                        let (cmin, cmax) = pl.content_range(sel.panel);
+                        let col_min = cmin.saturating_sub(5);
+                        sel.end_col = col.max(col_min).min(cmax.saturating_sub(1));
+                        sel.end_row = row
+                            .max(pl.inner_y)
+                            .min(pl.inner_end_y.saturating_sub(1));
+                    }
+                }
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                if let Some(ref mut sel) = self.diff_view.selection {
+                    sel.dragging = false;
+                    if sel.start_col == sel.end_col && sel.start_row == sel.end_row {
+                        self.diff_view.selection = None;
+                    }
+                }
+            }
+            MouseEventKind::ScrollUp => {
+                if rect_contains(diff_rect, col, row) {
+                    self.diff_view.selection = None;
+                    if mouse.modifiers.contains(KeyModifiers::SHIFT) {
+                        self.diff_view.scroll_left(4);
+                    } else {
+                        self.diff_view.scroll_up(3);
+                    }
+                } else if rect_contains(files_rect, col, row) {
+                    let len = self.diff_mode.visible_files_len();
+                    if len > 0 {
+                        self.diff_mode.diff_files_selected = self.diff_mode.diff_files_selected.saturating_sub(3);
+                        self.needs_diff_refresh = true;
+                    }
+                }
+            }
+            MouseEventKind::ScrollDown => {
+                if rect_contains(diff_rect, col, row) {
+                    self.diff_view.selection = None;
+                    if mouse.modifiers.contains(KeyModifiers::SHIFT) {
+                        self.diff_view.scroll_right(4);
+                    } else {
+                        self.diff_view.scroll_down(3);
+                    }
+                } else if rect_contains(files_rect, col, row) {
+                    let len = self.diff_mode.visible_files_len();
+                    if len > 0 {
+                        self.diff_mode.diff_files_selected = (self.diff_mode.diff_files_selected + 3).min(len - 1);
+                        self.needs_diff_refresh = true;
+                    }
+                }
+            }
+            MouseEventKind::ScrollLeft => {
+                if rect_contains(diff_rect, col, row) {
+                    self.diff_view.scroll_left(4);
+                }
+            }
+            MouseEventKind::ScrollRight => {
+                if rect_contains(diff_rect, col, row) {
                     self.diff_view.scroll_right(4);
                 }
             }
@@ -2717,6 +2940,10 @@ fn matches_key(key: KeyEvent, binding: &str) -> bool {
     } else {
         false
     }
+}
+
+fn rect_contains(r: ratatui::layout::Rect, col: u16, row: u16) -> bool {
+    col >= r.x && col < r.x + r.width && row >= r.y && row < r.y + r.height
 }
 
 fn setup_terminal() -> Result<Term> {

--- a/src/gui/modes/diff_mode.rs
+++ b/src/gui/modes/diff_mode.rs
@@ -1,0 +1,315 @@
+use crate::model::{Branch, Commit, CommitFile, Remote, Tag};
+
+/// Which panel is focused within diff mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffModeFocus {
+    SelectorA,
+    SelectorB,
+    CommitFiles,
+    DiffExploration,
+}
+
+impl DiffModeFocus {
+    pub fn from_number(n: u32) -> Option<Self> {
+        match n {
+            1 => Some(Self::SelectorA),
+            2 => Some(Self::SelectorB),
+            3 => Some(Self::CommitFiles),
+            4 => Some(Self::DiffExploration),
+            _ => None,
+        }
+    }
+
+    pub fn next(&self) -> Self {
+        match self {
+            Self::SelectorA => Self::SelectorB,
+            Self::SelectorB => Self::CommitFiles,
+            Self::CommitFiles => Self::DiffExploration,
+            Self::DiffExploration => Self::SelectorA,
+        }
+    }
+}
+
+/// The kind of ref candidate shown in the search dropdown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefKind {
+    Branch,
+    RemoteBranch,
+    Tag,
+    Commit,
+}
+
+/// A single candidate in the ref search dropdown.
+#[derive(Debug, Clone)]
+pub struct RefCandidate {
+    pub display: String,
+    pub ref_value: String,
+    pub kind: RefKind,
+}
+
+/// Which selector combobox is being edited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffModeSelector {
+    A,
+    B,
+}
+
+/// State for the diff/compare mode screen.
+pub struct DiffModeState {
+    pub active: bool,
+
+    // A and B refs
+    pub ref_a: String,
+    pub ref_b: String,
+    pub ref_a_display: String,
+    pub ref_b_display: String,
+
+    // Combobox editing state
+    pub editing: Option<DiffModeSelector>,
+    pub textarea: Option<tui_textarea::TextArea<'static>>,
+    pub search_results: Vec<RefCandidate>,
+    pub search_selected: usize,
+    pub dropdown_scroll: usize,
+
+    // Focus
+    pub focus: DiffModeFocus,
+
+    // Commit files for A..B diff
+    pub diff_files: Vec<CommitFile>,
+    pub diff_files_selected: usize,
+    pub diff_files_scroll: usize,
+
+    // Tree view for commit files
+    pub show_tree: bool,
+    pub tree_nodes: Vec<crate::model::file_tree::CommitFileTreeNode>,
+    pub collapsed_dirs: std::collections::HashSet<String>,
+}
+
+impl DiffModeState {
+    pub fn new() -> Self {
+        Self {
+            active: false,
+            ref_a: String::new(),
+            ref_b: String::new(),
+            ref_a_display: String::new(),
+            ref_b_display: String::new(),
+            editing: None,
+            textarea: None,
+            search_results: Vec::new(),
+            search_selected: 0,
+            dropdown_scroll: 0,
+            focus: DiffModeFocus::SelectorA,
+            diff_files: Vec::new(),
+            diff_files_selected: 0,
+            diff_files_scroll: 0,
+            show_tree: false,
+            tree_nodes: Vec::new(),
+            collapsed_dirs: std::collections::HashSet::new(),
+        }
+    }
+
+    pub fn enter(&mut self) {
+        self.active = true;
+        self.ref_a.clear();
+        self.ref_b.clear();
+        self.ref_a_display.clear();
+        self.ref_b_display.clear();
+        self.editing = None;
+        self.textarea = None;
+        self.search_results.clear();
+        self.search_selected = 0;
+        self.dropdown_scroll = 0;
+        self.focus = DiffModeFocus::SelectorA;
+        self.diff_files.clear();
+        self.diff_files_selected = 0;
+        self.diff_files_scroll = 0;
+        self.show_tree = false;
+        self.tree_nodes.clear();
+        self.collapsed_dirs.clear();
+    }
+
+    pub fn exit(&mut self) {
+        self.active = false;
+        self.editing = None;
+        self.textarea = None;
+        self.search_results.clear();
+        self.diff_files.clear();
+        self.tree_nodes.clear();
+        self.collapsed_dirs.clear();
+    }
+
+    pub fn swap_refs(&mut self) {
+        std::mem::swap(&mut self.ref_a, &mut self.ref_b);
+        std::mem::swap(&mut self.ref_a_display, &mut self.ref_b_display);
+        self.diff_files.clear();
+        self.diff_files_selected = 0;
+        self.diff_files_scroll = 0;
+    }
+
+    pub fn has_both_refs(&self) -> bool {
+        !self.ref_a.is_empty() && !self.ref_b.is_empty()
+    }
+
+    /// Get the current query text from the textarea.
+    pub fn query_text(&self) -> String {
+        self.textarea
+            .as_ref()
+            .map(|ta| ta.lines()[0].clone())
+            .unwrap_or_default()
+    }
+
+    /// Start editing a selector combobox with a textarea.
+    pub fn start_editing(&mut self, selector: DiffModeSelector) {
+        self.editing = Some(selector);
+        // Pre-fill with the ref value (e.g. short hash), not the display string
+        // (which may include a long commit message)
+        let prefill = match selector {
+            DiffModeSelector::A => &self.ref_a,
+            DiffModeSelector::B => &self.ref_b,
+        };
+        let mut ta = crate::gui::popup::make_textarea("Type a branch, tag, commit, or ref...");
+        if !prefill.is_empty() {
+            ta.insert_str(prefill);
+        }
+        self.textarea = Some(ta);
+        self.search_results.clear();
+        self.search_selected = 0;
+        self.dropdown_scroll = 0;
+    }
+
+    /// Cancel editing without applying.
+    pub fn cancel_editing(&mut self) {
+        self.editing = None;
+        self.textarea = None;
+        self.search_results.clear();
+        self.search_selected = 0;
+        self.dropdown_scroll = 0;
+    }
+
+    /// Apply the selected search result (or raw query) to the active selector.
+    pub fn confirm_selection(&mut self) {
+        let Some(selector) = self.editing else { return };
+
+        let query = self.query_text();
+        let (ref_value, display) = if let Some(candidate) = self.search_results.get(self.search_selected) {
+            (candidate.ref_value.clone(), candidate.display.clone())
+        } else if !query.is_empty() {
+            // Allow raw input like HEAD~1, commit hashes, etc.
+            (query.clone(), query)
+        } else {
+            self.editing = None;
+            self.textarea = None;
+            return;
+        };
+
+        match selector {
+            DiffModeSelector::A => {
+                self.ref_a = ref_value;
+                self.ref_a_display = display;
+            }
+            DiffModeSelector::B => {
+                self.ref_b = ref_value;
+                self.ref_b_display = display;
+            }
+        }
+
+        self.editing = None;
+        self.textarea = None;
+        self.search_results.clear();
+        self.search_selected = 0;
+        self.dropdown_scroll = 0;
+        self.diff_files.clear();
+        self.diff_files_selected = 0;
+        self.diff_files_scroll = 0;
+    }
+
+    /// Build all ref candidates and scroll to the best match for the current query.
+    /// All items are always shown — the query just moves the cursor to the best match.
+    pub fn search_refs(
+        &mut self,
+        branches: &[Branch],
+        tags: &[Tag],
+        commits: &[Commit],
+        remotes: &[Remote],
+    ) {
+        self.search_results.clear();
+
+        // Local branches
+        for branch in branches {
+            self.search_results.push(RefCandidate {
+                display: branch.name.clone(),
+                ref_value: branch.name.clone(),
+                kind: RefKind::Branch,
+            });
+        }
+
+        // Remote branches
+        for remote in remotes {
+            for rb in &remote.branches {
+                let full = rb.full_name();
+                self.search_results.push(RefCandidate {
+                    display: full.clone(),
+                    ref_value: full,
+                    kind: RefKind::RemoteBranch,
+                });
+            }
+        }
+
+        // Tags
+        for tag in tags {
+            self.search_results.push(RefCandidate {
+                display: tag.name.clone(),
+                ref_value: tag.name.clone(),
+                kind: RefKind::Tag,
+            });
+        }
+
+        // Commits
+        for commit in commits.iter().take(200) {
+            let hash_short = if commit.hash.len() >= 7 { &commit.hash[..7] } else { &commit.hash };
+            let display = format!("{} {}", hash_short, commit.name);
+            self.search_results.push(RefCandidate {
+                display,
+                ref_value: commit.hash.clone(),
+                kind: RefKind::Commit,
+            });
+        }
+
+        // Jump cursor to best match
+        let q = self.query_text().to_lowercase();
+        if !q.is_empty() {
+            // Find first item whose display or ref_value matches
+            if let Some(idx) = self.search_results.iter().position(|c| {
+                c.display.to_lowercase().contains(&q)
+                    || c.ref_value.to_lowercase().starts_with(&q)
+            }) {
+                self.search_selected = idx;
+            }
+        } else {
+            self.search_selected = 0;
+        }
+
+        self.ensure_dropdown_visible(10);
+    }
+
+    /// Ensure the dropdown scroll keeps the selected item visible.
+    pub fn ensure_dropdown_visible(&mut self, max_visible: usize) {
+        if max_visible == 0 {
+            return;
+        }
+        if self.search_selected < self.dropdown_scroll {
+            self.dropdown_scroll = self.search_selected;
+        } else if self.search_selected >= self.dropdown_scroll + max_visible {
+            self.dropdown_scroll = self.search_selected + 1 - max_visible;
+        }
+    }
+
+    /// Number of visible commit files (accounts for tree view).
+    pub fn visible_files_len(&self) -> usize {
+        if self.show_tree {
+            self.tree_nodes.len()
+        } else {
+            self.diff_files.len()
+        }
+    }
+}

--- a/src/gui/modes/mod.rs
+++ b/src/gui/modes/mod.rs
@@ -1,1 +1,2 @@
+pub mod diff_mode;
 pub mod patch_building;

--- a/src/gui/presentation/diff_mode.rs
+++ b/src/gui/presentation/diff_mode.rs
@@ -1,0 +1,381 @@
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
+
+use crate::config::Theme;
+use crate::gui::modes::diff_mode::{DiffModeFocus, DiffModeState, RefKind};
+use crate::model::{CommitFile, FileChangeStatus};
+use crate::model::file_tree::CommitFileTreeNode;
+use crate::pager::side_by_side::{self, DiffViewState};
+
+/// Max items visible in the dropdown at once.
+const DROPDOWN_MAX_VISIBLE: usize = 10;
+
+pub fn render(
+    frame: &mut Frame,
+    state: &DiffModeState,
+    diff_view: &mut DiffViewState,
+    theme: &Theme,
+) {
+    let area = frame.area();
+
+    // Overall layout: sidebar (left) | diff panel (right) | status bar at bottom
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(area);
+
+    let content = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(33), Constraint::Percentage(67)])
+        .split(outer[0]);
+
+    // Left sidebar: [A selector (3 lines)] [B selector (3 lines)] [Commit Files (rest)]
+    let sidebar = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Min(1),
+        ])
+        .split(content[0]);
+
+    render_selector(frame, sidebar[0], state, DiffModeFocus::SelectorA, theme);
+    render_selector(frame, sidebar[1], state, DiffModeFocus::SelectorB, theme);
+    render_commit_files(frame, sidebar[2], state, theme);
+
+    // Right panel: diff exploration
+    render_diff_panel(frame, content[1], state, diff_view, theme);
+
+    // Text selection highlight overlay and tooltip (must be before popups/dropdowns)
+    crate::gui::views::render_selection_overlay(frame, diff_view, content[1]);
+
+    // Status bar
+    render_status_bar(frame, outer[1], state);
+
+    // Render combobox dropdown overlay on top of the sidebar
+    if state.editing.is_some() {
+        render_dropdown(frame, sidebar, state, theme);
+    }
+}
+
+fn render_selector(
+    frame: &mut Frame,
+    area: Rect,
+    state: &DiffModeState,
+    which: DiffModeFocus,
+    theme: &Theme,
+) {
+    let (is_a, focused, editing, display, number_label) = match which {
+        DiffModeFocus::SelectorA => (
+            true,
+            state.focus == DiffModeFocus::SelectorA,
+            matches!(state.editing, Some(crate::gui::modes::diff_mode::DiffModeSelector::A)),
+            &state.ref_a_display,
+            " 1 A ",
+        ),
+        DiffModeFocus::SelectorB => (
+            false,
+            state.focus == DiffModeFocus::SelectorB,
+            matches!(state.editing, Some(crate::gui::modes::diff_mode::DiffModeSelector::B)),
+            &state.ref_b_display,
+            " 2 B ",
+        ),
+        _ => return,
+    };
+
+    let border = if focused || editing {
+        theme.active_border
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    let block = Block::default()
+        .title(number_label)
+        .borders(Borders::ALL)
+        .border_style(border);
+
+    if editing {
+        // Render the textarea inside the block
+        if let Some(ref ta) = state.textarea {
+            let inner = block.inner(area);
+            frame.render_widget(block, area);
+            frame.render_widget(&*ta, inner);
+        }
+    } else {
+        let text = if display.is_empty() {
+            "Press Enter to select ref..."
+        } else {
+            display.as_str()
+        };
+        let style = if display.is_empty() {
+            Style::default().fg(Color::DarkGray)
+        } else {
+            Style::default().fg(Color::Cyan)
+        };
+        let widget = Paragraph::new(Span::styled(format!(" {}", text), style)).block(block);
+        frame.render_widget(widget, area);
+    }
+}
+
+fn render_commit_files(
+    frame: &mut Frame,
+    area: Rect,
+    state: &DiffModeState,
+    theme: &Theme,
+) {
+    let focused = state.focus == DiffModeFocus::CommitFiles;
+    let border = if focused {
+        theme.active_border
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    let tree_indicator = if state.show_tree { " (tree)" } else { "" };
+    let title = format!(" 3 Commit Files ({}{}) ", state.diff_files.len(), tree_indicator);
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(border);
+
+    if state.diff_files.is_empty() {
+        let msg = if state.has_both_refs() {
+            "No files changed"
+        } else {
+            "Select refs A and B to compare"
+        };
+        let widget = Paragraph::new(Span::styled(
+            format!(" {}", msg),
+            Style::default().fg(Color::DarkGray),
+        ))
+        .block(block);
+        frame.render_widget(widget, area);
+        return;
+    }
+
+    if state.show_tree {
+        let items: Vec<ListItem> = state
+            .tree_nodes
+            .iter()
+            .map(|node| render_tree_node(node, state, theme))
+            .collect();
+
+        let list = List::new(items)
+            .block(block)
+            .highlight_style(theme.selected_line);
+
+        let mut list_state = ListState::default();
+        list_state.select(Some(state.diff_files_selected));
+        frame.render_stateful_widget(list, area, &mut list_state);
+    } else {
+        let items: Vec<ListItem> = state
+            .diff_files
+            .iter()
+            .map(|file| {
+                let (status_style, status_icon) = commit_file_status_display(file, theme);
+                let line = Line::from(vec![
+                    Span::styled(format!(" {} ", status_icon), status_style),
+                    Span::styled(file.name.clone(), Style::default().fg(Color::White)),
+                ]);
+                ListItem::new(line)
+            })
+            .collect();
+
+        let list = List::new(items)
+            .block(block)
+            .highlight_style(theme.selected_line);
+
+        let mut list_state = ListState::default();
+        list_state.select(Some(state.diff_files_selected));
+        frame.render_stateful_widget(list, area, &mut list_state);
+    }
+}
+
+fn render_tree_node<'a>(
+    node: &CommitFileTreeNode,
+    state: &DiffModeState,
+    theme: &Theme,
+) -> ListItem<'a> {
+    let indent = "  ".repeat(node.depth);
+    if node.is_dir {
+        let is_collapsed = state.collapsed_dirs.contains(&node.path);
+        let icon = if is_collapsed { "▶ " } else { "▼ " };
+        let line = Line::from(vec![
+            Span::styled(
+                format!("  {}{}", indent, icon),
+                Style::default().fg(Color::White),
+            ),
+            Span::styled(node.name.clone(), Style::default().fg(Color::White)),
+        ]);
+        ListItem::new(line)
+    } else if let Some(file_idx) = node.file_index {
+        if let Some(file) = state.diff_files.get(file_idx) {
+            let (status_style, status_icon) = commit_file_status_display(file, theme);
+            let line = Line::from(vec![
+                Span::styled(format!(" {} ", status_icon), status_style),
+                Span::raw(indent),
+                Span::styled(node.name.clone(), Style::default().fg(Color::White)),
+            ]);
+            ListItem::new(line)
+        } else {
+            ListItem::new(Line::raw(""))
+        }
+    } else {
+        ListItem::new(Line::raw(""))
+    }
+}
+
+fn render_diff_panel(
+    frame: &mut Frame,
+    area: Rect,
+    state: &DiffModeState,
+    diff_view: &mut DiffViewState,
+    theme: &Theme,
+) {
+    let focused = state.focus == DiffModeFocus::DiffExploration;
+
+    if !diff_view.is_empty() {
+        side_by_side::render_diff(frame, area, diff_view, theme, focused);
+    } else {
+        let border = if focused {
+            theme.active_border
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+        let block = Block::default()
+            .title(" 4 Diff ")
+            .borders(Borders::ALL)
+            .border_style(border);
+        let widget = Paragraph::new(Span::styled(
+            " Select a file to view diff",
+            Style::default().fg(Color::DarkGray),
+        ))
+        .block(block);
+        frame.render_widget(widget, area);
+    }
+}
+
+fn render_status_bar(frame: &mut Frame, area: Rect, state: &DiffModeState) {
+    let hints = if state.editing.is_some() {
+        vec![
+            ("Enter", "select"),
+            ("Esc", "cancel"),
+            ("↑↓", "navigate"),
+        ]
+    } else {
+        vec![
+            ("q", "exit"),
+            ("Tab", "cycle"),
+            ("1-4", "panel"),
+            ("<c-s>", "swap"),
+            ("`", "tree"),
+            ("?", "help"),
+        ]
+    };
+
+    let spans: Vec<Span> = hints
+        .iter()
+        .flat_map(|(key, desc)| {
+            vec![
+                Span::styled(
+                    format!(" {} ", key),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(format!("{} ", desc), Style::default().fg(Color::DarkGray)),
+            ]
+        })
+        .collect();
+
+    let bar = Paragraph::new(Line::from(spans));
+    frame.render_widget(bar, area);
+}
+
+fn render_dropdown(
+    frame: &mut Frame,
+    sidebar: std::rc::Rc<[Rect]>,
+    state: &DiffModeState,
+    theme: &Theme,
+) {
+    // Position dropdown below the relevant selector
+    let anchor = if matches!(state.editing, Some(crate::gui::modes::diff_mode::DiffModeSelector::A)) {
+        sidebar[0]
+    } else {
+        sidebar[1]
+    };
+
+    let total = state.search_results.len();
+    if total == 0 {
+        return;
+    }
+
+    let max_items = DROPDOWN_MAX_VISIBLE.min(total);
+    let dropdown_height = (max_items as u16) + 2; // +2 for borders
+    let available_height = frame.area().height.saturating_sub(anchor.y + anchor.height);
+    let dropdown_area = Rect {
+        x: anchor.x,
+        y: anchor.y + anchor.height,
+        width: anchor.width,
+        height: dropdown_height.min(available_height),
+    };
+
+    if dropdown_area.height < 3 {
+        return;
+    }
+
+    frame.render_widget(Clear, dropdown_area);
+
+    // Compute visible window
+    let visible_count = (dropdown_area.height as usize).saturating_sub(2); // -2 for borders
+    let scroll = state.dropdown_scroll;
+    let visible_end = (scroll + visible_count).min(total);
+
+    let items: Vec<ListItem> = state
+        .search_results
+        .iter()
+        .skip(scroll)
+        .take(visible_end - scroll)
+        .map(|candidate| {
+            let kind_label = match candidate.kind {
+                RefKind::Branch => Span::styled("[branch] ", Style::default().fg(Color::Green)),
+                RefKind::RemoteBranch => {
+                    Span::styled("[remote] ", Style::default().fg(Color::Magenta))
+                }
+                RefKind::Tag => Span::styled("[tag] ", Style::default().fg(Color::Yellow)),
+                RefKind::Commit => Span::styled("[commit] ", Style::default().fg(Color::Blue)),
+            };
+            let line = Line::from(vec![
+                Span::raw(" "),
+                kind_label,
+                Span::styled(candidate.display.clone(), Style::default().fg(Color::White)),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.active_border);
+
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(theme.selected_line);
+
+    let mut list_state = ListState::default();
+    // Selected index relative to the visible window
+    let relative_selected = state.search_selected.saturating_sub(scroll);
+    list_state.select(Some(relative_selected));
+    frame.render_stateful_widget(list, dropdown_area, &mut list_state);
+}
+
+fn commit_file_status_display<'a>(file: &CommitFile, theme: &Theme) -> (Style, &'a str) {
+    match file.status {
+        FileChangeStatus::Added => (theme.file_staged, "A "),
+        FileChangeStatus::Deleted => (Style::default().fg(Color::Red), "D "),
+        FileChangeStatus::Modified => (theme.file_unstaged, "M "),
+        FileChangeStatus::Renamed => (Style::default().fg(Color::Yellow), "R "),
+        FileChangeStatus::Copied => (Style::default().fg(Color::Cyan), "C "),
+        FileChangeStatus::Unmerged => (Style::default().fg(Color::Red), "U "),
+    }
+}

--- a/src/gui/presentation/mod.rs
+++ b/src/gui/presentation/mod.rs
@@ -1,5 +1,6 @@
 pub mod branches;
 pub mod commit_files;
+pub mod diff_mode;
 pub mod commits;
 pub mod files;
 pub mod graph;

--- a/src/gui/views.rs
+++ b/src/gui/views.rs
@@ -1098,7 +1098,7 @@ fn render_status_bar(
 
 /// Render mouse text selection highlight overlay and copy tooltip on the diff view.
 /// `panel_rect` is the main diff panel Rect — selection is rendered only within the selected side.
-fn render_selection_overlay(frame: &mut Frame, diff_view: &mut DiffViewState, panel_rect: Rect) {
+pub fn render_selection_overlay(frame: &mut Frame, diff_view: &mut DiffViewState, panel_rect: Rect) {
     use crate::pager::ChangeType;
 
     let selection = match &diff_view.selection {
@@ -1231,7 +1231,7 @@ fn render_selection_overlay(frame: &mut Frame, diff_view: &mut DiffViewState, pa
     }
 }
 
-fn render_popup(frame: &mut Frame, popup: &PopupState, area: Rect, spinner_frame: usize) {
+pub fn render_popup(frame: &mut Frame, popup: &PopupState, area: Rect, spinner_frame: usize) {
     let popup_width = (area.width * 60 / 100).min(60).max(30);
     let x = (area.width.saturating_sub(popup_width)) / 2;
 


### PR DESCRIPTION
mode for refs

Add a new diff/compare mode (W key) allowing users to select two refs
(branches, tags, commits) and explore side-by-side file diffs.

Features:
- Searchable combobox dropdowns for ref selection (A and B)
- File list view with tree/flat toggle (backtick key)
- Side-by-side diff exploration with full navigation controls
- Keyboard shortcuts: Tab (cycle), 1-4 (jump panel), Ctrl+S (swap),
  {/} (hunks), [/] (toggle view), g/G (top/bottom)
- Mouse support for clicking, scrolling, and text selection in diff

Implementation:
- New git commands: diff_refs_files() and diff_refs_file()
- Complete state management (DiffModeState) with dropdown search
- Controller for key and mouse event handling
- Presentation layer with dedicated rendering

<img width="682" height="422" alt="image" src="https://github.com/user-attachments/assets/a15d973a-03b4-4a98-ad0e-3c04eeb60b1d" />
