### PR TITLE
feat(config): load from ~/.config/lazygitrs with lazygit fallback

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,6 +12,14 @@ pub use keybindings::KeybindingConfig;
 pub use theme::{Theme, ColorTheme, COLOR_THEMES};
 pub use user_config::UserConfig;
 
+pub fn config_dir_candidates() -> Vec<PathBuf> {
+    let home_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let base = std::env::var("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| home_dir.join(".config"));
+    vec![base.join("lazygitrs"), base.join("lazygit")]
+}
+
 /// Top-level application configuration.
 pub struct AppConfig {
     pub debug: bool,
@@ -26,16 +34,21 @@ pub struct AppConfig {
 impl AppConfig {
     pub fn load(debug: bool) -> Result<Self> {
         let home_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-
-        let config_dir = std::env::var("XDG_CONFIG_HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| home_dir.join(".config"))
-            .join("lazygit");
+        let candidates = config_dir_candidates();
+        let config_dir = candidates
+            .into_iter()
+            .find(|dir| dir.join("config.yml").exists())
+            .unwrap_or_else(|| {
+                std::env::var("XDG_CONFIG_HOME")
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|_| home_dir.join(".config"))
+                    .join("lazygitrs")
+            });
 
         let state_dir = std::env::var("XDG_STATE_HOME")
             .map(PathBuf::from)
             .unwrap_or_else(|_| home_dir.join(".local").join("state"))
-            .join("lazygit");
+            .join("lazygitrs");
 
         let state_path = state_dir.join("state.yml");
 

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -664,56 +664,54 @@ static CUSTOM_THEMES_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/src/themes");
 
 // ── User theme discovery & loading ──────────────────────────────────────
 
-fn user_themes_dir() -> Option<std::path::PathBuf> {
-    let config_dir = std::env::var("XDG_CONFIG_HOME")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs::home_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("."))
-                .join(".config")
-        })
-        .join("lazygit")
-        .join("themes");
-    Some(config_dir)
+fn user_themes_dirs() -> Vec<std::path::PathBuf> {
+    crate::config::config_dir_candidates()
+        .into_iter()
+        .map(|dir| dir.join("themes"))
+        .collect()
 }
 
 fn discover_user_themes() -> Option<Vec<(String, String)>> {
-    let dir = user_themes_dir()?;
-    if !dir.is_dir() {
-        return None;
-    }
-
     let mut result = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(&dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) == Some("json") {
-                if let Ok(contents) = std::fs::read_to_string(&path) {
-                    if let Ok(theme_json) = serde_json::from_str::<ThemeJson>(&contents) {
-                        result.push((theme_json.id.clone(), theme_json.name.clone()));
+    for dir in user_themes_dirs() {
+        if !dir.is_dir() {
+            continue;
+        }
+        if let Ok(entries) = std::fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) == Some("json") {
+                    if let Ok(contents) = std::fs::read_to_string(&path) {
+                        if let Ok(theme_json) = serde_json::from_str::<ThemeJson>(&contents) {
+                            result.push((theme_json.id.clone(), theme_json.name.clone()));
+                        }
                     }
                 }
             }
         }
     }
 
-    Some(result)
+    if result.is_empty() {
+        None
+    } else {
+        Some(result)
+    }
 }
 
 fn load_user_theme(id: &str) -> Option<Theme> {
-    let dir = user_themes_dir()?;
-    if !dir.is_dir() {
-        return None;
-    }
-
-    if let Ok(entries) = std::fs::read_dir(&dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) == Some("json") {
-                if let Ok(contents) = std::fs::read_to_string(&path) {
-                    if let Ok(theme_json) = serde_json::from_str::<ThemeJson>(&contents) {
-                        if theme_json.id == id {
-                            return Some(theme_json.to_theme());
+    for dir in user_themes_dirs() {
+        if !dir.is_dir() {
+            continue;
+        }
+        if let Ok(entries) = std::fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) == Some("json") {
+                    if let Ok(contents) = std::fs::read_to_string(&path) {
+                        if let Ok(theme_json) = serde_json::from_str::<ThemeJson>(&contents) {
+                            if theme_json.id == id {
+                                return Some(theme_json.to_theme());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This pull request improves the configuration directory discovery logic to support both `lazygitrs` and legacy `lazygit` directories, and updates theme discovery and loading to search in both locations. This enhances compatibility for users migrating from `lazygit` and provides a more robust configuration experience.

**Configuration directory improvements:**

* Added a new `config_dir_candidates` function in `src/config/mod.rs` to return possible configuration directories, prioritizing both `lazygitrs` and `lazygit` under the user's config directory.
* Updated `AppConfig::load` in `src/config/mod.rs` to search for `config.yml` in both candidate directories and use the first one found, defaulting to `lazygitrs` if none exist. State files are now also stored under `lazygitrs`.

**Theme discovery and loading enhancements:**

* Refactored theme loading in `src/config/theme.rs` to use the new `config_dir_candidates` logic, allowing user themes to be discovered and loaded from both `lazygitrs/themes` and `lazygit/themes` directories.
* Updated logic in `discover_user_themes` and `load_user_theme` to iterate over all candidate theme directories, improving compatibility and user experience. [[1]](diffhunk://#diff-164a6717124d72160124f6badf3dabb85331db2d14ffa63dfb2496d7a1f4ab6fR692-L708) [[2]](diffhunk://#diff-164a6717124d72160124f6badf3dabb85331db2d14ffa63dfb2496d7a1f4ab6fR720)