### PR TITLE
fix(gui): add reverse toggle panel keybinding for Shift+Tab

### DIFF
--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -40,6 +40,8 @@ pub struct UniversalKeybinding {
     pub quit_without_changing_directory: String,
     #[serde(rename = "togglePanel")]
     pub toggle_panel: String,
+    #[serde(rename = "togglePanelReverse")]
+    pub toggle_panel_reverse: String,
     #[serde(rename = "prevItem")]
     pub prev_item: String,
     #[serde(rename = "nextItem")]
@@ -118,6 +120,7 @@ impl Default for UniversalKeybinding {
             return_key: "<escape>".into(),
             quit_without_changing_directory: "Q".into(),
             toggle_panel: "<tab>".into(),
+            toggle_panel_reverse: "<backtab>".into(),
             prev_item: "k".into(),
             next_item: "j".into(),
             prev_item_alt: "<up>".into(),
@@ -398,6 +401,7 @@ pub fn parse_key(s: &str) -> Option<KeyEvent> {
             "enter" => Some(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
             "escape" | "esc" => Some(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
             "tab" => Some(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+            "backtab" | "shift-tab" => Some(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)),
             "backspace" | "bs" => {
                 Some(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE))
             }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1512,6 +1512,13 @@ impl Gui {
             return Ok(());
         }
 
+        // Shift+Tab to switch windows in reverse
+        if matches_key(key, &keybindings.universal.toggle_panel_reverse) {
+            self.exit_sub_contexts();
+            self.context_mgr.prev_window();
+            return Ok(());
+        }
+
         // Arrow keys / h/l to switch windows
         if matches_key(key, &keybindings.universal.prev_block)
             || matches_key(key, &keybindings.universal.prev_block_alt)

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -3079,6 +3079,7 @@ impl Gui {
                 HelpEntry { key: kb.universal.quit_alt1.clone(), description: "Quit (alt)".into() },
                 HelpEntry { key: kb.universal.return_key.clone(), description: "Return / Cancel".into() },
                 HelpEntry { key: kb.universal.toggle_panel.clone(), description: "Next panel".into() },
+                HelpEntry { key: kb.universal.toggle_panel_reverse.clone(), description: "Previous panel".into() },
                 HelpEntry { key: kb.universal.prev_item.clone(), description: "Previous item".into() },
                 HelpEntry { key: kb.universal.next_item.clone(), description: "Next item".into() },
                 HelpEntry { key: kb.universal.prev_page.clone(), description: "Page up".into() },


### PR DESCRIPTION
This pull request adds support for a reverse panel toggle keybinding (Shift+Tab) throughout the application. The main changes introduce a new `toggle_panel_reverse` keybinding, set its default to `<backtab>`, update key parsing to recognize Shift+Tab, and handle this keybinding in the GUI to switch panels in reverse.

Keybinding additions and configuration:

* Added a new `toggle_panel_reverse` field to the `UniversalKeybinding` struct, with a default value of `<backtab>`. [[1]](diffhunk://#diff-f87b09bb32e095b4525cb0dbc096844d0bc2116b884c6b28de79af1aafdf5401R43-R44) [[2]](diffhunk://#diff-f87b09bb32e095b4525cb0dbc096844d0bc2116b884c6b28de79af1aafdf5401R123)
* Updated the key parser to recognize `"backtab"` and `"shift-tab"` as Shift+Tab, mapping them to the correct key event.

GUI behavior:

* Implemented handling for the new `toggle_panel_reverse` keybinding in the GUI, allowing users to switch panels in reverse order using Shift+Tab.