### PR TITLE
Ai commit shortcut

### DIFF
--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -187,6 +187,8 @@ impl Default for StatusKeybinding {
 pub struct FilesKeybinding {
     #[serde(rename = "commitChanges")]
     pub commit_changes: String,
+    #[serde(rename = "generateAICommit")]
+    pub generate_ai_commit: String,
     #[serde(rename = "commitChangesWithoutHook")]
     pub commit_changes_without_hook: String,
     #[serde(rename = "amendLastCommit")]
@@ -210,6 +212,7 @@ impl Default for FilesKeybinding {
     fn default() -> Self {
         Self {
             commit_changes: "c".into(),
+            generate_ai_commit: "G".into(),
             commit_changes_without_hook: "w".into(),
             amend_last_commit: "A".into(),
             commit_changes_with_editor: "C".into(),

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -212,7 +212,7 @@ impl Default for FilesKeybinding {
     fn default() -> Self {
         Self {
             commit_changes: "c".into(),
-            generate_ai_commit: "G".into(),
+            generate_ai_commit: "<c-g>".into(),
             commit_changes_without_hook: "w".into(),
             amend_last_commit: "A".into(),
             commit_changes_with_editor: "C".into(),

--- a/src/gui/controller/files.rs
+++ b/src/gui/controller/files.rs
@@ -244,6 +244,7 @@ fn open_ai_commit_prompt(gui: &mut Gui) -> Result<()> {
                 gui.popup = PopupState::CommitInput {
                     summary_textarea: make_commit_summary_textarea(),
                     body_textarea: make_commit_body_textarea(),
+                    body_state: crate::gui::popup::BodySoftWrap::new(),
                     focus: CommitInputFocus::Summary,
                     on_confirm: Box::new(|gui, message| {
                         if !message.is_empty() {
@@ -263,6 +264,7 @@ fn open_ai_commit_prompt(gui: &mut Gui) -> Result<()> {
     gui.popup = PopupState::CommitInput {
         summary_textarea: make_commit_summary_textarea(),
         body_textarea: make_commit_body_textarea(),
+        body_state: crate::gui::popup::BodySoftWrap::new(),
         focus: CommitInputFocus::Summary,
         on_confirm: Box::new(|gui, message| {
             if !message.is_empty() {

--- a/src/gui/controller/files.rs
+++ b/src/gui/controller/files.rs
@@ -41,6 +41,9 @@ pub fn handle_key(gui: &mut Gui, key: KeyEvent, keybindings: &KeybindingConfig) 
     if matches_key(key, &keybindings.files.commit_changes) {
         return open_commit_prompt(gui);
     }
+    if matches_key(key, &keybindings.files.generate_ai_commit) {
+        return open_ai_commit_prompt(gui);
+    }
 
     if matches_key(key, &keybindings.files.toggle_staged_all) {
         return toggle_stage_all(gui);
@@ -224,6 +227,52 @@ fn open_commit_prompt(gui: &mut Gui) -> Result<()> {
             Ok(())
         }),
     };
+    Ok(())
+}
+
+fn open_ai_commit_prompt(gui: &mut Gui) -> Result<()> {
+    let model = gui.model.lock().unwrap();
+    let any_staged = model.files.iter().any(|f| f.has_staged_changes);
+    drop(model);
+
+    if !any_staged {
+        gui.popup = PopupState::Confirm {
+            title: "No files staged".to_string(),
+            message: "You have not staged any files. Stage all and generate AI commit message?".to_string(),
+            on_confirm: Box::new(|gui| {
+                gui.git.stage_all()?;
+                gui.popup = PopupState::CommitInput {
+                    summary_textarea: make_commit_summary_textarea(),
+                    body_textarea: make_commit_body_textarea(),
+                    focus: CommitInputFocus::Summary,
+                    on_confirm: Box::new(|gui, message| {
+                        if !message.is_empty() {
+                            gui.git.create_commit(message, false)?;
+                            gui.needs_refresh = true;
+                        }
+                        Ok(())
+                    }),
+                };
+                gui.trigger_ai_commit_generation_from_editor();
+                Ok(())
+            }),
+        };
+        return Ok(());
+    }
+
+    gui.popup = PopupState::CommitInput {
+        summary_textarea: make_commit_summary_textarea(),
+        body_textarea: make_commit_body_textarea(),
+        focus: CommitInputFocus::Summary,
+        on_confirm: Box::new(|gui, message| {
+            if !message.is_empty() {
+                gui.git.create_commit(message, false)?;
+                gui.needs_refresh = true;
+            }
+            Ok(())
+        }),
+    };
+    gui.trigger_ai_commit_generation_from_editor();
     Ok(())
 }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -991,6 +991,30 @@ impl Gui {
         });
     }
 
+    fn begin_ai_commit_generation_ui(&mut self) {
+        self.popup = PopupState::Loading {
+            title: "AI Commit".to_string(),
+            message: "Generating commit message...".to_string(),
+        };
+        self.start_ai_commit_generation();
+    }
+
+    pub fn trigger_ai_commit_generation_from_editor(&mut self) {
+        let generate_cmd = self.config.user_config.git.commit.generate_command.trim();
+        if generate_cmd.is_empty() {
+            self.popup = PopupState::Message {
+                title: "AI generation unavailable".to_string(),
+                message: "Set git.commit.generateCommand in your config first.".to_string(),
+                kind: MessageKind::Error,
+            };
+            return;
+        }
+
+        let stashed = std::mem::replace(&mut self.popup, PopupState::None);
+        self.pending_commit_popup = Some(stashed);
+        self.begin_ai_commit_generation_ui();
+    }
+
     /// Request diff loading on a background thread if selection changed.
     fn maybe_request_diff(&mut self) {
         // Rebase mode has no diff to load
@@ -2420,10 +2444,9 @@ impl Gui {
                     }
                 } else if is_commit
                     && !confirm_focused
-                    && key.code == KeyCode::Char('o')
-                    && key.modifiers.contains(KeyModifiers::CONTROL)
+                    && matches_key(key, &self.config.user_config.keybinding.commit_message.commit_menu)
                 {
-                    // <c-o> in commit message editor: open commit menu
+                    // Commit message editor menu key (configurable)
                     self.show_commit_editor_menu()?;
                 } else if !confirm_focused {
                     // Forward all other keys to the textarea (only when textarea is focused)
@@ -2465,7 +2488,6 @@ impl Gui {
                 }
             }
             PopupState::CommitInput { focus, .. } => {
-                use crossterm::event::KeyModifiers;
                 let focus = *focus;
 
                 // Tab toggles focus between summary and body
@@ -2545,9 +2567,13 @@ impl Gui {
                     self.saved_commit_popup = Some(stashed);
                     self.commit_history_idx = None;
                 }
-                // Ctrl+O: open commit menu
-                else if key.code == KeyCode::Char('o') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                // Open commit menu key (configurable)
+                else if matches_key(key, &self.config.user_config.keybinding.commit_message.commit_menu) {
                     self.show_commit_editor_menu()?;
+                }
+                // AI generate key (configurable)
+                else if matches_key(key, &self.config.user_config.keybinding.commit_message.ai_generate) {
+                    self.trigger_ai_commit_generation_from_editor();
                 }
                 // Up/Down on summary: cycle commit history
                 else if focus == popup::CommitInputFocus::Summary
@@ -3202,6 +3228,7 @@ impl Gui {
                     HelpEntry { key: "<enter>".into(), description: "Toggle dir / Focus diff".into() },
                     HelpEntry { key: "<space>".into(), description: "Stage / Unstage".into() },
                     HelpEntry { key: kb.files.commit_changes.clone(), description: "Commit".into() },
+                    HelpEntry { key: kb.files.generate_ai_commit.clone(), description: "Generate AI commit".into() },
                     HelpEntry { key: kb.files.amend_last_commit.clone(), description: "Amend last commit".into() },
                     HelpEntry { key: kb.files.commit_changes_with_editor.clone(), description: "Commit with editor".into() },
                     HelpEntry { key: kb.files.toggle_staged_all.clone(), description: "Toggle stage all".into() },
@@ -3618,11 +3645,7 @@ impl Gui {
                 description: String::new(),
                 key: Some("g".to_string()),
                 action: Some(Box::new(|gui| {
-                    gui.popup = PopupState::Loading {
-                        title: "AI Commit".to_string(),
-                        message: "Generating commit message...".to_string(),
-                    };
-                    gui.start_ai_commit_generation();
+                    gui.begin_ai_commit_generation_ui();
                     Ok(())
                 })),
             });

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2488,6 +2488,7 @@ impl Gui {
                 }
             }
             PopupState::CommitInput { focus, .. } => {
+                use crossterm::event::KeyModifiers;
                 let focus = *focus;
 
                 // Tab toggles focus between summary and body


### PR DESCRIPTION
### Summary

Adds keyboard shortcut support for triggering AI commit message generation directly from the commit editor, making the workflow faster without needing to go through commit menus.

### Changes

#### `feat(commit): add configurable AI commit shortcuts`
- Adds the default `<c-g>` shortcut to trigger AI commit message generation directly from the files list or within the commit editor.
- Replaces the hardcoded commit menu shortcut with a configurable key read from `keybinding.commit_message.commit_menu`.
- Adds `trigger_ai_commit_generation_from_editor()` — initiates AI generation from within the commit popup, stashing and restoring the popup state.