### PR TITLE
fix(cherry-pick): continue/abort/skip, reset keybinding, and correct multi-commit order

### DIFF
--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -94,4 +94,26 @@ impl GitCommands {
             .run_expecting_success()?;
         Ok(())
     }
+
+    pub fn continue_cherry_pick(&self) -> Result<()> {
+        self.git()
+            .args(&["cherry-pick", "--continue"])
+            .env("GIT_EDITOR", "true")
+            .run_expecting_success()?;
+        Ok(())
+    }
+
+    pub fn abort_cherry_pick(&self) -> Result<()> {
+        self.git()
+            .args(&["cherry-pick", "--abort"])
+            .run_expecting_success()?;
+        Ok(())
+    }
+
+    pub fn skip_cherry_pick(&self) -> Result<()> {
+        self.git()
+            .args(&["cherry-pick", "--skip"])
+            .run_expecting_success()?;
+        Ok(())
+    }
 }

--- a/src/gui/controller/commits.rs
+++ b/src/gui/controller/commits.rs
@@ -48,6 +48,11 @@ pub fn handle_key(gui: &mut Gui, key: KeyEvent, keybindings: &KeybindingConfig) 
         return paste_commits(gui);
     }
 
+    if matches_key(key, &keybindings.commits.reset_cherry_pick) {
+        gui.cherry_pick_clipboard.clear();
+        return Ok(());
+    }
+
     if matches_key(key, &keybindings.commits.squash_above_commits) {
         return squash_above_commits_menu(gui);
     }
@@ -300,7 +305,11 @@ fn paste_commits(gui: &mut Gui) -> Result<()> {
     }
 
     let n = gui.cherry_pick_clipboard.len();
-    let hashes = gui.cherry_pick_clipboard.clone();
+    let mut hashes = gui.cherry_pick_clipboard.clone();
+    // The clipboard stores commits newest-first (matching the visual list order).
+    // git cherry-pick applies commits in argument order, so we must reverse to
+    // apply oldest-first and preserve the intended history.
+    hashes.reverse();
 
     gui.popup = PopupState::Confirm {
         title: "Cherry-pick".to_string(),

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -3538,7 +3538,7 @@ impl Gui {
         &mut self,
         is_rebasing: bool,
         is_merging: bool,
-        _is_cherry_picking: bool,
+        is_cherry_picking: bool,
     ) -> Result<()> {
         let mut items = Vec::new();
 
@@ -3588,8 +3588,42 @@ impl Gui {
             });
         }
 
+        if is_cherry_picking {
+            items.push(popup::MenuItem {
+                label: "Continue cherry-pick".to_string(),
+                description: "git cherry-pick --continue".to_string(),
+                key: Some("c".to_string()),
+                action: Some(Box::new(|gui| {
+                    gui.git.continue_cherry_pick()?;
+                    gui.needs_refresh = true;
+                    Ok(())
+                })),
+            });
+            items.push(popup::MenuItem {
+                label: "Abort cherry-pick".to_string(),
+                description: "git cherry-pick --abort".to_string(),
+                key: Some("a".to_string()),
+                action: Some(Box::new(|gui| {
+                    gui.git.abort_cherry_pick()?;
+                    gui.cherry_pick_clipboard.clear();
+                    gui.needs_refresh = true;
+                    Ok(())
+                })),
+            });
+            items.push(popup::MenuItem {
+                label: "Skip this commit".to_string(),
+                description: "git cherry-pick --skip".to_string(),
+                key: Some("s".to_string()),
+                action: Some(Box::new(|gui| {
+                    gui.git.skip_cherry_pick()?;
+                    gui.needs_refresh = true;
+                    Ok(())
+                })),
+            });
+        }
+
         self.popup = PopupState::Menu {
-            title: "Rebase/Merge options".to_string(),
+            title: "Rebase/Merge/Cherry-pick options".to_string(),
             items,
             selected: 0,
             loading_index: None,


### PR DESCRIPTION
## Summary

Fixes three bugs in the cherry-pick implementation.

### Bug 1 — Critical: conflict resolution was impossible

`show_rebase_options_menu` received `is_cherry_picking` but the parameter was named `_is_cherry_picking` and completely ignored — no menu items were built for it. When a cherry-pick hit a conflict the menu opened empty and the user was stuck with no way to continue or abort from the TUI.

**Fix:** added `continue_cherry_pick()`, `abort_cherry_pick()`, and `skip_cherry_pick()` git wrappers in `status.rs`, and wired them into the options menu with keys `c` / `a` / `s`.

### Bug 2 — Dead keybinding: `<Ctrl-q>` did nothing

`reset_cherry_pick` was declared in the config with default `<c-q>` but was never matched in the key handler.

**Fix:** added the `matches_key` check in `handle_key` so pressing `<Ctrl-q>` now clears the clipboard.

### Bug 3 — Wrong history order for multi-commit cherry-pick

The commit list is shown newest-first. Hashes were pushed to the clipboard in visual order and passed to `git cherry-pick` unchanged — oldest commit ended up applied last, reversing history.

**Fix:** the clipboard is reversed before being passed to `git.cherry_pick()`, so oldest is applied first.

## Files changed

- `src/git/status.rs` — add `continue_cherry_pick`, `abort_cherry_pick`, `skip_cherry_pick`
- `src/gui/mod.rs` — fix `_is_cherry_picking` dead param; add continue/abort/skip menu items
- `src/gui/controller/commits.rs` — wire `reset_cherry_pick` keybinding; reverse hashes before paste