### PR TITLE
fix: stop background git from stealing keystrokes; re-architect terminal input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "include_dir",
+ "libc",
  "once_cell",
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ unicode-width = "0.2"
 tui-textarea = { version = "0.7", features = ["crossterm"] }
 textwrap = "0.16.2"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/src/git/ai_commit.rs
+++ b/src/git/ai_commit.rs
@@ -36,6 +36,7 @@ pub fn generate_commit_message_cancellable(
         .args(["diff", "--cached"])
         .current_dir(repo_path)
         .env("GIT_OPTIONAL_LOCKS", "0")
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()?;

--- a/src/gui/input.rs
+++ b/src/gui/input.rs
@@ -1,0 +1,553 @@
+//! Terminal input.
+//!
+//! Two jobs, both of which the render loop used to do badly by hand:
+//!
+//! 1. **Read continuously.** Reading only once per rendered frame means a
+//!    terminal control sequence that a PTY read split after the initial `ESC`
+//!    (crossterm-rs/crossterm#993) has its tail sitting in the buffer for a
+//!    whole frame. By the time anyone looks, the pieces no longer look like one
+//!    sequence, and a focus-in report (`ESC [ I`) turns into `Esc`, `[`, `I` —
+//!    three bogus shortcuts. A dedicated thread that blocks on `event::read()`
+//!    picks the tail up microseconds later, so reassembly is reliable and its
+//!    timing window can stay short enough to never delay a real `Esc`.
+//!
+//! 2. **Hand over whole batches.** Auto-repeat delivers keys far faster than a
+//!    full repaint. Processing one key per frame lets the queue grow without
+//!    bound, so held keys keep scrolling long after release. [`InputReader`]
+//!    exposes every event queued so far and lets the caller draw once.
+//!
+//! Reassembly never leaks an escape payload into shortcut handling: a partial
+//! sequence is dropped rather than replayed byte by byte. It is also lossless
+//! for real keys — anything that cannot appear inside the sequence being parsed
+//! is handed back as the keypress it is.
+
+use std::io;
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+/// How long to look for something immediately behind a bare `Esc`.
+///
+/// A sequence is split by a read boundary, not by the terminal: the tail was
+/// written in the same breath as the `ESC` and is already in the buffer, so the
+/// reader thread sees it in microseconds. The budget only has to cover scheduler
+/// jitter, so one frame is ample — and it is short enough that a real `Esc`
+/// press feels immediate, which the old 25ms-per-byte-after-a-full-frame scheme
+/// could not manage. No human types `Esc` then `[` inside this window.
+const INTRODUCER_PROBE: Duration = Duration::from_millis(15);
+
+/// How long to wait per byte once an introducer has confirmed a sequence is in
+/// flight. At that point no real keypress is being held up, so this can be
+/// generous enough to absorb a slow or descheduled terminal.
+const CONTINUATION_WINDOW: Duration = Duration::from_millis(100);
+
+/// Upper bound on how long one reassembly may take, so a terminal dribbling
+/// bytes can never stall input.
+const SEQUENCE_DEADLINE: Duration = Duration::from_millis(400);
+
+/// Guard against a pathological run of parameter bytes.
+const MAX_SEQUENCE_BYTES: usize = 64;
+
+/// Most events handed to the UI in one batch. Keeps a paste storm or a very long
+/// auto-repeat burst from starving the renderer.
+const MAX_BATCH: usize = 512;
+
+/// Reads terminal events on a dedicated thread and serves them in batches.
+pub struct InputReader {
+    rx: Receiver<Event>,
+}
+
+impl InputReader {
+    pub fn spawn() -> Self {
+        let (tx, rx) = mpsc::channel();
+        thread::Builder::new()
+            .name("input-reader".into())
+            .spawn(move || {
+                // Exits when the receiver goes away at shutdown.
+                loop {
+                    match next_events(&mut CrosstermSource) {
+                        Ok(events) => {
+                            for event in events {
+                                if tx.send(event).is_err() {
+                                    return;
+                                }
+                            }
+                        }
+                        Err(_) => return,
+                    }
+                }
+            })
+            .expect("spawn input reader thread");
+        Self { rx }
+    }
+
+    /// Wait up to `timeout` for input, then return it together with everything
+    /// else already queued. Empty means the timeout expired with nothing to do.
+    pub fn wait_batch(&self, timeout: Duration) -> Vec<Event> {
+        let mut batch = Vec::new();
+        match self.rx.recv_timeout(timeout) {
+            Ok(event) => batch.push(event),
+            Err(RecvTimeoutError::Timeout) => return batch,
+            Err(RecvTimeoutError::Disconnected) => return batch,
+        }
+        while batch.len() < MAX_BATCH {
+            match self.rx.try_recv() {
+                Ok(event) => batch.push(event),
+                Err(_) => break,
+            }
+        }
+        batch
+    }
+}
+
+/// Source of already-parsed crossterm events, abstracted so the reassembly state
+/// machine can be tested without a terminal.
+trait EventSource {
+    /// Next event, or `None` if `timeout` expired first.
+    fn next(&mut self, timeout: Duration) -> io::Result<Option<Event>>;
+}
+
+struct CrosstermSource;
+
+impl EventSource for CrosstermSource {
+    fn next(&mut self, timeout: Duration) -> io::Result<Option<Event>> {
+        if timeout.is_zero() {
+            return Ok(None);
+        }
+        if event::poll(timeout)? {
+            return event::read().map(Some);
+        }
+        Ok(None)
+    }
+}
+
+/// Blocking read of the next logical event(s).
+fn next_events(source: &mut impl EventSource) -> io::Result<Vec<Event>> {
+    // A bare `Esc` is the only event that can be the head of a sequence that
+    // crossterm failed to keep together, so everything else passes straight
+    // through.
+    let first = loop {
+        if let Some(event) = source.next(Duration::from_secs(3600))? {
+            break event;
+        }
+    };
+    let Event::Key(key) = first else {
+        return Ok(vec![first]);
+    };
+    if key.code != KeyCode::Esc || key.kind != KeyEventKind::Press {
+        return Ok(vec![Event::Key(key)]);
+    }
+    resolve_escape(source)
+}
+
+/// Decide what a bare `Esc` actually was: a keypress, an `Alt`-modified key, or
+/// the start of a control sequence that arrived in pieces.
+fn resolve_escape(source: &mut impl EventSource) -> io::Result<Vec<Event>> {
+    let esc = Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+    let Some(second) = source.next(INTRODUCER_PROBE)? else {
+        return Ok(vec![esc]);
+    };
+    // Anything that is not a plain character cannot continue a sequence, so
+    // deliver both rather than dropping either.
+    let Event::Key(mut key) = second else {
+        return Ok(vec![esc, second]);
+    };
+    let KeyCode::Char(introducer) = key.code else {
+        return Ok(vec![esc, Event::Key(key)]);
+    };
+
+    let deadline = Instant::now() + SEQUENCE_DEADLINE;
+    match introducer {
+        '[' => read_csi(source, deadline),
+        'O' => read_ss3(source, deadline),
+        // OSC/DCS/PM/APC carry a string payload that is never a shortcut. Read
+        // to its terminator and emit nothing.
+        ']' | 'P' | '^' | '_' => {
+            consume_control_string(source, deadline)?;
+            Ok(Vec::new())
+        }
+        // A real `Alt`+key press, which is how terminals without the enhanced
+        // keyboard protocol encode it.
+        _ => {
+            key.modifiers |= KeyModifiers::ALT;
+            Ok(vec![Event::Key(key)])
+        }
+    }
+}
+
+/// Read the body of a `CSI` sequence and turn it into the event it encodes.
+fn read_csi(source: &mut impl EventSource, deadline: Instant) -> io::Result<Vec<Event>> {
+    let mut body = String::new();
+    loop {
+        let Some(event) = next_before(source, deadline)? else {
+            // Truncated sequence: drop it rather than replay its bytes as keys.
+            return Ok(Vec::new());
+        };
+        // A non-character event ends the sequence. Keep the event, drop the
+        // partial sequence.
+        let Event::Key(key) = event else {
+            return Ok(vec![event]);
+        };
+        let KeyCode::Char(ch) = key.code else {
+            return Ok(vec![Event::Key(key)]);
+        };
+
+        if is_csi_final(ch) {
+            if let Some(event) = parse_csi(&body, ch) {
+                return Ok(vec![event]);
+            }
+            // Unrecognised. Most letters are legal `CSI` terminators, so `ESC [`
+            // followed by a plain letter is far more likely a stray `ESC` plus a
+            // real keypress than a control sequence — losing `q` there would
+            // read as the app ignoring quit. Only drop the character when it
+            // could actually terminate a report a terminal sends us.
+            if body.is_empty() && !is_report_final(ch) {
+                return Ok(vec![Event::Key(key)]);
+            }
+            return Ok(Vec::new());
+        }
+        if !is_csi_body(ch) || body.len() >= MAX_SEQUENCE_BYTES {
+            // Cannot belong to this sequence, so it is a genuine keypress.
+            return Ok(vec![Event::Key(key)]);
+        }
+        body.push(ch);
+    }
+}
+
+/// `SS3` (`ESC O x`) encodes one key in the single byte that follows.
+fn read_ss3(source: &mut impl EventSource, deadline: Instant) -> io::Result<Vec<Event>> {
+    let Some(event) = next_before(source, deadline)? else {
+        return Ok(Vec::new());
+    };
+    let Event::Key(key) = event else {
+        return Ok(vec![event]);
+    };
+    let KeyCode::Char(ch) = key.code else {
+        return Ok(vec![Event::Key(key)]);
+    };
+    let code = match ch {
+        'A' => KeyCode::Up,
+        'B' => KeyCode::Down,
+        'C' => KeyCode::Right,
+        'D' => KeyCode::Left,
+        'H' => KeyCode::Home,
+        'F' => KeyCode::End,
+        'P' => KeyCode::F(1),
+        'Q' => KeyCode::F(2),
+        'R' => KeyCode::F(3),
+        'S' => KeyCode::F(4),
+        _ => return Ok(vec![Event::Key(key)]),
+    };
+    Ok(vec![Event::Key(KeyEvent::new(code, KeyModifiers::NONE))])
+}
+
+/// Swallow a control string up to `ST` (`ESC \`) or `BEL`.
+fn consume_control_string(source: &mut impl EventSource, deadline: Instant) -> io::Result<()> {
+    let mut saw_esc = false;
+    loop {
+        let Some(event) = next_before(source, deadline)? else {
+            return Ok(());
+        };
+        let Event::Key(key) = event else {
+            return Ok(());
+        };
+        match key.code {
+            KeyCode::Esc => saw_esc = true,
+            KeyCode::Char('\\') if saw_esc => return Ok(()),
+            KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => return Ok(()),
+            _ => saw_esc = false,
+        }
+    }
+}
+
+fn next_before(source: &mut impl EventSource, deadline: Instant) -> io::Result<Option<Event>> {
+    let budget = deadline
+        .saturating_duration_since(Instant::now())
+        .min(CONTINUATION_WINDOW);
+    source.next(budget)
+}
+
+/// Parameter and intermediate bytes, i.e. everything legal inside a `CSI` body.
+fn is_csi_body(ch: char) -> bool {
+    matches!(ch, '\u{20}'..='\u{3f}')
+}
+
+fn is_csi_final(ch: char) -> bool {
+    matches!(ch, '\u{40}'..='\u{7e}')
+}
+
+/// Final bytes of the parameterless reports a terminal actually sends us: focus
+/// in/out, `CSI Z` for back-tab, the cursor keys, and legacy X10 mouse. Anything
+/// else with an empty parameter list is treated as a real keypress instead.
+fn is_report_final(ch: char) -> bool {
+    matches!(
+        ch,
+        'I' | 'O' | 'Z' | 'M' | 'A' | 'B' | 'C' | 'D' | 'H' | 'F'
+    )
+}
+
+/// Modifier mask from the enhanced-keyboard/xterm encoding, which is 1-based and
+/// may carry an event type after a `:`.
+fn parse_modifiers(value: &str) -> KeyModifiers {
+    let mask = value
+        .split(':')
+        .next()
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(1)
+        .saturating_sub(1);
+    let mut modifiers = KeyModifiers::NONE;
+    modifiers.set(KeyModifiers::SHIFT, mask & 1 != 0);
+    modifiers.set(KeyModifiers::ALT, mask & 2 != 0);
+    modifiers.set(KeyModifiers::CONTROL, mask & 4 != 0);
+    modifiers.set(KeyModifiers::SUPER, mask & 8 != 0);
+    modifiers.set(KeyModifiers::HYPER, mask & 16 != 0);
+    modifiers.set(KeyModifiers::META, mask & 32 != 0);
+    modifiers
+}
+
+/// Rebuild the event a `CSI <body> <final>` sequence stands for.
+fn parse_csi(body: &str, final_byte: char) -> Option<Event> {
+    if body.is_empty() {
+        match final_byte {
+            'I' => return Some(Event::FocusGained),
+            'O' => return Some(Event::FocusLost),
+            'Z' => {
+                return Some(Event::Key(KeyEvent::new(
+                    KeyCode::BackTab,
+                    KeyModifiers::SHIFT,
+                )));
+            }
+            _ => {}
+        }
+    }
+
+    let modifiers = body
+        .rsplit(';')
+        .next()
+        .filter(|_| body.contains(';'))
+        .map(parse_modifiers)
+        .unwrap_or(KeyModifiers::NONE);
+
+    let code = match final_byte {
+        'A' => KeyCode::Up,
+        'B' => KeyCode::Down,
+        'C' => KeyCode::Right,
+        'D' => KeyCode::Left,
+        'H' => KeyCode::Home,
+        'F' => KeyCode::End,
+        'u' => {
+            let codepoint = body.split(';').next()?.split(':').next()?.parse().ok()?;
+            match codepoint {
+                9 => KeyCode::Tab,
+                13 => KeyCode::Enter,
+                27 => KeyCode::Esc,
+                127 => KeyCode::Backspace,
+                value => KeyCode::Char(char::from_u32(value)?),
+            }
+        }
+        '~' => match body.split(';').next()? {
+            "1" | "7" => KeyCode::Home,
+            "2" => KeyCode::Insert,
+            "3" => KeyCode::Delete,
+            "4" | "8" => KeyCode::End,
+            "5" => KeyCode::PageUp,
+            "6" => KeyCode::PageDown,
+            _ => return None,
+        },
+        _ => return None,
+    };
+
+    Some(Event::Key(KeyEvent {
+        code,
+        modifiers,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feeds a scripted list of events; `None` entries stand for a timeout.
+    struct Scripted(std::collections::VecDeque<Option<Event>>);
+
+    impl Scripted {
+        fn new(items: Vec<Option<Event>>) -> Self {
+            Self(items.into_iter().collect())
+        }
+
+        /// Everything the state machine yields for the scripted input, assuming
+        /// the leading `Esc` has already been taken.
+        fn resolve(items: Vec<Option<Event>>) -> Vec<Event> {
+            let mut source = Scripted::new(items);
+            resolve_escape(&mut source).expect("resolve")
+        }
+    }
+
+    impl EventSource for Scripted {
+        fn next(&mut self, _timeout: Duration) -> io::Result<Option<Event>> {
+            Ok(self.0.pop_front().flatten())
+        }
+    }
+
+    fn ch(c: char) -> Option<Event> {
+        Some(Event::Key(KeyEvent::new(
+            KeyCode::Char(c),
+            KeyModifiers::NONE,
+        )))
+    }
+
+    fn key(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    #[test]
+    fn bare_escape_stays_an_escape() {
+        assert_eq!(Scripted::resolve(vec![None]), vec![key(KeyCode::Esc)]);
+    }
+
+    #[test]
+    fn split_focus_report_never_reaches_shortcut_handling() {
+        // `ESC [ I` arriving as three key events must become a focus event, not
+        // the `I` that opens the interactive rebase picker.
+        assert_eq!(
+            Scripted::resolve(vec![ch('['), ch('I')]),
+            vec![Event::FocusGained]
+        );
+    }
+
+    #[test]
+    fn split_arrow_key_is_reassembled() {
+        assert_eq!(
+            Scripted::resolve(vec![ch('['), ch('A')]),
+            vec![key(KeyCode::Up)]
+        );
+    }
+
+    #[test]
+    fn split_modified_key_keeps_its_modifier() {
+        assert_eq!(
+            Scripted::resolve(vec![ch('['), ch('4'), ch('9'), ch(';'), ch('9'), ch('u')]),
+            vec![Event::Key(KeyEvent {
+                code: KeyCode::Char('1'),
+                modifiers: KeyModifiers::SUPER,
+                kind: KeyEventKind::Press,
+                state: KeyEventState::NONE,
+            })]
+        );
+    }
+
+    #[test]
+    fn escape_then_letter_is_alt_modified() {
+        assert_eq!(
+            Scripted::resolve(vec![ch('x')]),
+            vec![Event::Key(KeyEvent::new(
+                KeyCode::Char('x'),
+                KeyModifiers::ALT
+            ))]
+        );
+    }
+
+    #[test]
+    fn truncated_sequence_is_dropped_rather_than_leaked() {
+        // Payload bytes must never be replayed as keypresses.
+        assert_eq!(Scripted::resolve(vec![ch('['), ch('3'), None]), vec![]);
+    }
+
+    #[test]
+    fn key_that_cannot_continue_a_sequence_is_still_delivered() {
+        // `q` happens to be a legal `CSI` terminator, but `ESC [ q` is not a
+        // report any terminal sends, so quit must still get through.
+        assert_eq!(
+            Scripted::resolve(vec![ch('['), ch('q')]),
+            vec![key(KeyCode::Char('q'))]
+        );
+    }
+
+    #[test]
+    fn unmodelled_terminal_report_is_dropped_not_typed() {
+        // A device-attributes reply (`ESC [ ? 6 2 ; 2 2 c`) has to vanish rather
+        // than land in a text field.
+        assert_eq!(
+            Scripted::resolve(vec![
+                ch('['),
+                ch('?'),
+                ch('6'),
+                ch('2'),
+                ch(';'),
+                ch('2'),
+                ch('2'),
+                ch('c'),
+            ]),
+            vec![]
+        );
+    }
+
+    #[test]
+    fn interior_key_press_is_not_swallowed_by_a_stalled_sequence() {
+        // Enter cannot appear inside a `CSI` body, so it is a real keypress.
+        assert_eq!(
+            Scripted::resolve(vec![ch('['), ch('1'), Some(key(KeyCode::Enter))]),
+            vec![key(KeyCode::Enter)]
+        );
+    }
+
+    #[test]
+    fn typed_text_after_a_stray_escape_survives() {
+        // Non-ASCII input is neither a parameter nor a terminator byte.
+        assert_eq!(
+            Scripted::resolve(vec![ch('['), ch('é')]),
+            vec![key(KeyCode::Char('é'))]
+        );
+    }
+
+    #[test]
+    fn non_key_event_after_introducer_is_preserved() {
+        let resize = Event::Resize(80, 24);
+        assert_eq!(
+            Scripted::resolve(vec![ch('['), Some(resize.clone())]),
+            vec![resize]
+        );
+    }
+
+    #[test]
+    fn control_string_payload_is_swallowed_entirely() {
+        // An OSC reply must not spray its text into the UI.
+        assert_eq!(
+            Scripted::resolve(vec![
+                ch(']'),
+                ch('1'),
+                ch('1'),
+                ch(';'),
+                ch('r'),
+                ch('g'),
+                ch('b'),
+                Some(key(KeyCode::Esc)),
+                ch('\\'),
+            ]),
+            vec![]
+        );
+    }
+
+    #[test]
+    fn ss3_function_key_is_reassembled() {
+        assert_eq!(
+            Scripted::resolve(vec![ch('O'), ch('B')]),
+            vec![key(KeyCode::Down)]
+        );
+    }
+
+    #[test]
+    fn csi_grammar_classifies_parameter_and_final_bytes() {
+        assert!(is_csi_body('3'));
+        assert!(is_csi_body(';'));
+        assert!(!is_csi_body('q'));
+        assert!(is_csi_final('I'));
+        assert!(is_csi_final('u'));
+        assert!(!is_csi_final('3'));
+    }
+}

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,5 +1,6 @@
 pub mod context;
 pub mod controller;
+pub mod input;
 pub mod layout;
 pub mod modes;
 pub mod popup;
@@ -14,7 +15,7 @@ use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent};
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use crossterm::{Command, cursor, execute};
 use ratatui::Terminal;
@@ -31,6 +32,7 @@ use crate::pager::side_by_side::{
 };
 
 use self::context::{ContextId, ContextManager, SideWindow};
+use self::input::InputReader;
 use self::layout::LayoutState;
 use self::modes::diff_mode::DiffModeState;
 use self::modes::patch_building::PatchBuildingState;
@@ -66,10 +68,25 @@ fn list_picker_visible_height(terminal_height: usize) -> usize {
 }
 
 pub type Term = Terminal<CrosstermBackend<Stdout>>;
-const EVENT_DRAIN_LIMIT: usize = 256;
-const ESCAPE_CONTINUATION_TIMEOUT: Duration = Duration::from_millis(25);
-const MAX_ESCAPE_SEQUENCE_EVENTS: usize = 256;
 const COMMIT_DETAILS_DEBOUNCE: Duration = Duration::from_millis(120);
+
+/// How long the loop may sleep when there is nothing animating. Input wakes it
+/// immediately, so this only bounds how quickly a background result becomes
+/// visible.
+const IDLE_TICK: Duration = Duration::from_millis(120);
+
+/// Frame budget while a spinner is running or a background result is still
+/// outstanding. Also bounds how long a completed result waits to be picked up,
+/// so keep it comfortably below the threshold of noticing.
+const ANIMATION_TICK: Duration = Duration::from_millis(33);
+
+/// Spinner advance rate, derived from elapsed time so the animation speed does
+/// not depend on how often the loop happens to run.
+const SPINNER_PERIOD: Duration = Duration::from_millis(80);
+
+/// Redraw at least this often even when nothing is known to have changed, so a
+/// missed invalidation can never leave the screen stale for long.
+const MAX_FRAME_INTERVAL: Duration = Duration::from_millis(500);
 const MAX_CONCURRENT_DIFF_JOBS: usize = 2;
 const DIFF_PREVIEW_CACHE_ENTRIES: usize = 8;
 const DIFF_PREVIEW_CACHE_BYTES: usize = 32 * 1024 * 1024;
@@ -82,157 +99,6 @@ fn plain_char_key(key: KeyEvent, expected: char) -> bool {
         KeyModifiers::NONE
     };
     key.code == KeyCode::Char(expected) && key.modifiers == modifiers
-}
-
-fn parse_kitty_modifiers(value: &str) -> KeyModifiers {
-    let mask = value
-        .split(':')
-        .next()
-        .and_then(|value| value.parse::<u16>().ok())
-        .unwrap_or(1)
-        .saturating_sub(1);
-    let mut modifiers = KeyModifiers::NONE;
-    modifiers.set(KeyModifiers::SHIFT, mask & 1 != 0);
-    modifiers.set(KeyModifiers::ALT, mask & 2 != 0);
-    modifiers.set(KeyModifiers::CONTROL, mask & 4 != 0);
-    modifiers.set(KeyModifiers::SUPER, mask & 8 != 0);
-    modifiers.set(KeyModifiers::HYPER, mask & 16 != 0);
-    modifiers.set(KeyModifiers::META, mask & 32 != 0);
-    modifiers
-}
-
-fn parse_fragmented_escape_sequence(sequence: &str) -> Option<Event> {
-    if let Some(csi) = sequence.strip_prefix('[') {
-        let final_byte = csi.chars().last()?;
-        let body = &csi[..csi.len().saturating_sub(final_byte.len_utf8())];
-
-        if body.is_empty() {
-            match final_byte {
-                'I' => return Some(Event::FocusGained),
-                'O' => return Some(Event::FocusLost),
-                'Z' => {
-                    return Some(Event::Key(KeyEvent::new(
-                        KeyCode::BackTab,
-                        KeyModifiers::SHIFT,
-                    )));
-                }
-                _ => {}
-            }
-        }
-
-        let modifiers = body
-            .rsplit(';')
-            .next()
-            .filter(|_| body.contains(';'))
-            .map(parse_kitty_modifiers)
-            .unwrap_or(KeyModifiers::NONE);
-        let code = match final_byte {
-            'A' => KeyCode::Up,
-            'B' => KeyCode::Down,
-            'C' => KeyCode::Right,
-            'D' => KeyCode::Left,
-            'H' => KeyCode::Home,
-            'F' => KeyCode::End,
-            'u' => {
-                let codepoint = body.split(';').next()?.split(':').next()?.parse().ok()?;
-                match codepoint {
-                    9 => KeyCode::Tab,
-                    13 => KeyCode::Enter,
-                    27 => KeyCode::Esc,
-                    127 => KeyCode::Backspace,
-                    value => KeyCode::Char(char::from_u32(value)?),
-                }
-            }
-            '~' => match body.split(';').next()? {
-                "1" | "7" => KeyCode::Home,
-                "2" => KeyCode::Insert,
-                "3" => KeyCode::Delete,
-                "4" | "8" => KeyCode::End,
-                "5" => KeyCode::PageUp,
-                "6" => KeyCode::PageDown,
-                _ => return None,
-            },
-            _ => return None,
-        };
-        return Some(Event::Key(KeyEvent::new(code, modifiers)));
-    }
-
-    let code = match sequence {
-        "OA" => KeyCode::Up,
-        "OB" => KeyCode::Down,
-        "OC" => KeyCode::Right,
-        "OD" => KeyCode::Left,
-        "OH" => KeyCode::Home,
-        "OF" => KeyCode::End,
-        "OP" => KeyCode::F(1),
-        "OQ" => KeyCode::F(2),
-        "OR" => KeyCode::F(3),
-        "OS" => KeyCode::F(4),
-        _ => return None,
-    };
-    Some(Event::Key(KeyEvent::new(code, KeyModifiers::NONE)))
-}
-
-/// Work around crossterm-rs/crossterm#993, where a PTY read ending after the
-/// initial ESC can split one terminal control sequence into ordinary key events.
-fn read_terminal_events() -> io::Result<Vec<Event>> {
-    let first = event::read()?;
-    let Event::Key(first_key) = first else {
-        return Ok(vec![first]);
-    };
-    if first_key.code != KeyCode::Esc || first_key.kind != crossterm::event::KeyEventKind::Press {
-        return Ok(vec![Event::Key(first_key)]);
-    }
-
-    if !event::poll(ESCAPE_CONTINUATION_TIMEOUT)? {
-        return Ok(vec![Event::Key(first_key)]);
-    }
-    let second = event::read()?;
-    let Event::Key(mut second_key) = second else {
-        return Ok(vec![Event::Key(first_key), second]);
-    };
-    let KeyCode::Char(introducer @ ('[' | 'O' | ']' | 'P' | '^' | '_')) = second_key.code else {
-        second_key.modifiers |= KeyModifiers::ALT;
-        return Ok(vec![Event::Key(second_key)]);
-    };
-
-    let deadline = Instant::now() + ESCAPE_CONTINUATION_TIMEOUT;
-    let mut sequence = String::from(introducer);
-    let control_string = matches!(introducer, ']' | 'P' | '^' | '_');
-    let mut control_string_esc = false;
-    for _ in 0..MAX_ESCAPE_SEQUENCE_EVENTS {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() || !event::poll(remaining)? {
-            break;
-        }
-        let next = event::read()?;
-        let Event::Key(key) = next else {
-            return Ok(vec![next]);
-        };
-        if control_string {
-            if key.code == KeyCode::Char('g') && key.modifiers.contains(KeyModifiers::CONTROL) {
-                return Ok(Vec::new());
-            }
-            if control_string_esc && key.code == KeyCode::Char('\\') {
-                return Ok(Vec::new());
-            }
-            control_string_esc = key.code == KeyCode::Esc;
-            continue;
-        }
-        let KeyCode::Char(ch) = key.code else {
-            return Ok(vec![Event::Key(key)]);
-        };
-        sequence.push(ch);
-        if ch.is_ascii() && ('@'..='~').contains(&ch) {
-            return Ok(parse_fragmented_escape_sequence(&sequence)
-                .into_iter()
-                .collect());
-        }
-    }
-
-    // A confirmed but malformed/incomplete terminal sequence must never leak
-    // its payload into shortcut handling or text inputs.
-    Ok(Vec::new())
 }
 
 fn has_command_modifier(modifiers: KeyModifiers) -> bool {
@@ -260,19 +126,6 @@ pub(crate) fn textarea_input(
         _ => return textarea.input(key),
     };
     true
-}
-
-fn drain_pending_terminal_events(idle_timeout: Duration) {
-    for _ in 0..EVENT_DRAIN_LIMIT {
-        match event::poll(idle_timeout) {
-            Ok(true) => {
-                if event::read().is_err() {
-                    break;
-                }
-            }
-            Ok(false) | Err(_) => break,
-        }
-    }
 }
 
 /// A completed diff result from the background thread.
@@ -521,6 +374,11 @@ pub struct Gui {
     pub command_log: crate::os::cmd::CommandLog,
     pub show_command_log: bool,
     pub should_quit: bool,
+    /// Set whenever state that the screen reflects has changed. The loop paints
+    /// only when this is set (or something is animating), so an idle session
+    /// costs no CPU and a burst of held keys costs one frame instead of one per
+    /// key.
+    pub needs_redraw: bool,
     pub needs_refresh: bool,
     pub needs_files_refresh: bool,
     pub needs_diff_refresh: bool,
@@ -795,6 +653,7 @@ impl Gui {
             command_log,
             show_command_log: show_command_log_default,
             should_quit: false,
+            needs_redraw: true,
             needs_refresh: false,
             needs_files_refresh: false,
             needs_diff_refresh: true,
@@ -886,13 +745,36 @@ impl Gui {
         let size = terminal.size()?;
         self.layout.update_size(size.width, size.height);
 
-        let result = self.main_loop(&mut terminal);
+        // Start reading input before the first paint so nothing typed during
+        // startup is lost.
+        let input = InputReader::spawn();
+        let result = self.main_loop(&mut terminal, &input);
 
         restore_terminal(&mut terminal, keyboard_enhanced)?;
         result
     }
 
-    fn main_loop(&mut self, terminal: &mut Term) -> Result<()> {
+    /// True while a background operation is still expected to report back, which
+    /// is also exactly when a spinner or progress label is on screen.
+    fn async_work_pending(&self) -> bool {
+        self.initial_load_rx.is_some()
+            || self.refresh_in_progress
+            || self.diff_loading
+            || self.commit_page_loading
+            || self.auto_fetch_in_flight
+            || self.ai_commit_job.is_some()
+            || self.remote_op_label.is_some()
+            || self.needs_refresh
+            || self.needs_files_refresh
+            || self.needs_diff_refresh
+            || self
+                .remote_op_success_at
+                .is_some_and(|at| at.elapsed() < Duration::from_secs(5))
+    }
+
+    fn main_loop(&mut self, terminal: &mut Term, input: &InputReader) -> Result<()> {
+        let loop_started = Instant::now();
+        let mut last_frame_at = Instant::now();
         loop {
             // Drain any model parts that have arrived from the background load.
             if let Some(rx) = &self.initial_load_rx {
@@ -1005,237 +887,188 @@ impl Gui {
             // Check for completed background menu item operations
             self.receive_menu_async_results();
 
-            // Advance spinner animation
-            self.spinner_frame = self.spinner_frame.wrapping_add(1);
+            // Advance spinner animation from wall-clock time, so its speed does
+            // not change with how often the loop runs.
+            self.spinner_frame =
+                (loop_started.elapsed().as_millis() / SPINNER_PERIOD.as_millis()) as usize;
 
-            // Render
+            // Paint only when the screen would actually differ. `MAX_FRAME_INTERVAL`
+            // is a backstop so a missed invalidation self-corrects instead of
+            // leaving stale pixels.
+            let animating = self.async_work_pending();
+            let should_draw =
+                self.needs_redraw || animating || last_frame_at.elapsed() >= MAX_FRAME_INTERVAL;
+
             let theme = self.active_theme();
-            terminal.draw(|frame| {
-                if self.rebase_mode.active {
-                    presentation::rebase_mode::render(frame, &mut self.rebase_mode, &theme);
-                    // Render popup overlay on top of rebase mode
-                    if self.popup != PopupState::None {
-                        views::render_popup(
-                            frame,
-                            &self.popup,
-                            frame.area(),
-                            self.spinner_frame,
-                            &theme,
-                            false,
-                            !self
-                                .config
-                                .user_config
-                                .git
-                                .commit
-                                .generate_command
-                                .trim()
-                                .is_empty(),
-                        );
-                    } else if self.ai_commit_generation_active() {
-                        views::render_loading_overlay(
-                            frame,
-                            frame.area(),
-                            self.spinner_frame,
-                            &theme,
-                            "AI Commit",
-                            "Generating commit message...",
-                            Some(("Esc esc", "cancel")),
-                        );
-                    }
-                } else if self.diff_mode.active {
-                    let diff_loading_show = self.diff_loading
-                        && self
-                            .diff_loading_since
-                            .map(|t| t.elapsed() >= std::time::Duration::from_millis(50))
-                            .unwrap_or(false);
-                    presentation::diff_mode::render(
-                        frame,
-                        &mut self.diff_mode,
-                        &mut self.diff_view,
-                        &theme,
-                        self.diff_loading,
-                        diff_loading_show,
-                    );
-                    // Render popup overlay on top of diff mode (for ? help, errors, etc.)
-                    if self.popup != PopupState::None {
-                        views::render_popup(
-                            frame,
-                            &self.popup,
-                            frame.area(),
-                            self.spinner_frame,
-                            &theme,
-                            false,
-                            !self
-                                .config
-                                .user_config
-                                .git
-                                .commit
-                                .generate_command
-                                .trim()
-                                .is_empty(),
-                        );
-                    } else if self.ai_commit_generation_active() {
-                        views::render_loading_overlay(
-                            frame,
-                            frame.area(),
-                            self.spinner_frame,
-                            &theme,
-                            "AI Commit",
-                            "Generating commit message...",
-                            Some(("Esc esc", "cancel")),
-                        );
-                    }
-                } else {
-                    let model = self.model.lock().unwrap();
-                    let search_state = if self.search_active || !self.search_query.is_empty() {
-                        Some((
-                            self.search_query.as_str(),
-                            self.search_matches.len(),
-                            self.search_match_idx,
-                        ))
-                    } else {
-                        None
-                    };
-                    let cmd_log = self.command_log.lock().unwrap();
-                    views::render(
-                        frame,
-                        &model,
-                        &mut self.context_mgr,
-                        &self.layout,
-                        &self.popup,
-                        &self.config,
-                        &theme,
-                        &mut self.diff_view,
-                        &mut self.commit_list_cache,
-                        self.screen_mode,
-                        self.show_file_tree,
-                        &self.file_tree_nodes,
-                        &self.collapsed_dirs,
-                        self.diff_focused,
-                        search_state,
-                        self.search_textarea.as_ref(),
-                        &cmd_log,
-                        self.show_command_log,
-                        &self.commit_branch_filter,
-                        self.show_commit_file_tree,
-                        &self.commit_file_tree_nodes,
-                        &self.commit_files_collapsed_dirs,
-                        &self.commit_files_hash,
-                        &self.commit_files_message,
-                        &self.branch_commits_name,
-                        &self.remote_branches_name,
-                        self.sub_commits_parent_context,
-                        self.spinner_frame,
-                        self.remote_op_label.as_deref(),
-                        self.remote_op_success_at
-                            .map(|t| t.elapsed() < std::time::Duration::from_secs(5))
-                            .unwrap_or(false),
-                        &self.cherry_pick_clipboard,
-                        self.range_select_anchor,
-                        self.diff_loading,
-                        // Only show "Loading diff..." text after a short delay to avoid jitter on fast loads
-                        self.diff_loading
+            if should_draw {
+                self.needs_redraw = false;
+                last_frame_at = Instant::now();
+                terminal.draw(|frame| {
+                    if self.rebase_mode.active {
+                        presentation::rebase_mode::render(frame, &mut self.rebase_mode, &theme);
+                        // Render popup overlay on top of rebase mode
+                        if self.popup != PopupState::None {
+                            views::render_popup(
+                                frame,
+                                &self.popup,
+                                frame.area(),
+                                self.spinner_frame,
+                                &theme,
+                                false,
+                                !self
+                                    .config
+                                    .user_config
+                                    .git
+                                    .commit
+                                    .generate_command
+                                    .trim()
+                                    .is_empty(),
+                            );
+                        } else if self.ai_commit_generation_active() {
+                            views::render_loading_overlay(
+                                frame,
+                                frame.area(),
+                                self.spinner_frame,
+                                &theme,
+                                "AI Commit",
+                                "Generating commit message...",
+                                Some(("Esc esc", "cancel")),
+                            );
+                        }
+                    } else if self.diff_mode.active {
+                        let diff_loading_show = self.diff_loading
                             && self
                                 .diff_loading_since
                                 .map(|t| t.elapsed() >= std::time::Duration::from_millis(50))
-                                .unwrap_or(false),
-                        &self.commit_stats_cache,
-                        &self.commit_messages_cache,
-                        &mut self.commit_details_scroll,
-                        &mut self.commit_details_scroll_hash,
-                        self.show_commit_details,
-                        false,
-                        !self
-                            .config
-                            .user_config
-                            .git
-                            .commit
-                            .generate_command
-                            .trim()
-                            .is_empty(),
-                    );
-                    if self.popup == PopupState::None && self.ai_commit_generation_active() {
-                        views::render_loading_overlay(
+                                .unwrap_or(false);
+                        presentation::diff_mode::render(
                             frame,
-                            frame.area(),
-                            self.spinner_frame,
+                            &mut self.diff_mode,
+                            &mut self.diff_view,
                             &theme,
-                            "AI Commit",
-                            "Generating commit message...",
-                            Some(("Esc esc", "cancel")),
+                            self.diff_loading,
+                            diff_loading_show,
                         );
+                        // Render popup overlay on top of diff mode (for ? help, errors, etc.)
+                        if self.popup != PopupState::None {
+                            views::render_popup(
+                                frame,
+                                &self.popup,
+                                frame.area(),
+                                self.spinner_frame,
+                                &theme,
+                                false,
+                                !self
+                                    .config
+                                    .user_config
+                                    .git
+                                    .commit
+                                    .generate_command
+                                    .trim()
+                                    .is_empty(),
+                            );
+                        } else if self.ai_commit_generation_active() {
+                            views::render_loading_overlay(
+                                frame,
+                                frame.area(),
+                                self.spinner_frame,
+                                &theme,
+                                "AI Commit",
+                                "Generating commit message...",
+                                Some(("Esc esc", "cancel")),
+                            );
+                        }
+                    } else {
+                        let model = self.model.lock().unwrap();
+                        let search_state = if self.search_active || !self.search_query.is_empty() {
+                            Some((
+                                self.search_query.as_str(),
+                                self.search_matches.len(),
+                                self.search_match_idx,
+                            ))
+                        } else {
+                            None
+                        };
+                        let cmd_log = self.command_log.lock().unwrap();
+                        views::render(
+                            frame,
+                            &model,
+                            &mut self.context_mgr,
+                            &self.layout,
+                            &self.popup,
+                            &self.config,
+                            &theme,
+                            &mut self.diff_view,
+                            &mut self.commit_list_cache,
+                            self.screen_mode,
+                            self.show_file_tree,
+                            &self.file_tree_nodes,
+                            &self.collapsed_dirs,
+                            self.diff_focused,
+                            search_state,
+                            self.search_textarea.as_ref(),
+                            &cmd_log,
+                            self.show_command_log,
+                            &self.commit_branch_filter,
+                            self.show_commit_file_tree,
+                            &self.commit_file_tree_nodes,
+                            &self.commit_files_collapsed_dirs,
+                            &self.commit_files_hash,
+                            &self.commit_files_message,
+                            &self.branch_commits_name,
+                            &self.remote_branches_name,
+                            self.sub_commits_parent_context,
+                            self.spinner_frame,
+                            self.remote_op_label.as_deref(),
+                            self.remote_op_success_at
+                                .map(|t| t.elapsed() < std::time::Duration::from_secs(5))
+                                .unwrap_or(false),
+                            &self.cherry_pick_clipboard,
+                            self.range_select_anchor,
+                            self.diff_loading,
+                            // Only show "Loading diff..." text after a short delay to avoid jitter on fast loads
+                            self.diff_loading
+                                && self
+                                    .diff_loading_since
+                                    .map(|t| t.elapsed() >= std::time::Duration::from_millis(50))
+                                    .unwrap_or(false),
+                            &self.commit_stats_cache,
+                            &self.commit_messages_cache,
+                            &mut self.commit_details_scroll,
+                            &mut self.commit_details_scroll_hash,
+                            self.show_commit_details,
+                            false,
+                            !self
+                                .config
+                                .user_config
+                                .git
+                                .commit
+                                .generate_command
+                                .trim()
+                                .is_empty(),
+                        );
+                        if self.popup == PopupState::None && self.ai_commit_generation_active() {
+                            views::render_loading_overlay(
+                                frame,
+                                frame.area(),
+                                self.spinner_frame,
+                                &theme,
+                                "AI Commit",
+                                "Generating commit message...",
+                                Some(("Esc esc", "cancel")),
+                            );
+                        }
                     }
-                }
-            })?;
-
-            // Handle events
-            if event::poll(std::time::Duration::from_millis(16))? {
-                for terminal_event in read_terminal_events()? {
-                    match terminal_event {
-                        Event::Key(key) if key.kind == crossterm::event::KeyEventKind::Press => {
-                            if let Err(err) = self.handle_key(key) {
-                                self.show_error("Command failed", err);
-                            }
-                        }
-                        Event::Mouse(mouse) => self.handle_mouse(mouse),
-                        Event::Resize(w, h) => {
-                            self.layout.update_size(w, h);
-                            // Re-flow any active commit-message textarea to the new width so
-                            // wrapping stays consistent with what the user sees.
-                            let popup_width = (w * 60 / 100).min(60).max(30).min(w);
-                            let popup_inner = popup_width.saturating_sub(4) as usize;
-                            let config_width = self.config.user_config.git.commit.auto_wrap_width;
-                            let effective_width = if config_width > 0 {
-                                popup_inner.min(config_width)
-                            } else {
-                                popup_inner
-                            };
-                            match &mut self.popup {
-                                PopupState::Input {
-                                    textarea,
-                                    is_commit: true,
-                                    ..
-                                } => {
-                                    if effective_width > 0 {
-                                        auto_wrap_textarea(textarea, effective_width);
-                                    }
-                                }
-                                PopupState::Input {
-                                    textarea,
-                                    is_commit: false,
-                                    ..
-                                } => {
-                                    // Single-line input: re-flow the soft wrap to the new width.
-                                    let raw: String = textarea.lines().join("");
-                                    if popup_inner > 0 && !raw.is_empty() {
-                                        let mut new_ta = popup::make_textarea("");
-                                        new_ta.insert_str(&raw);
-                                        soft_wrap_textarea(&mut new_ta, popup_inner);
-                                        *textarea = new_ta;
-                                    }
-                                }
-                                PopupState::CommitInput {
-                                    body_textarea,
-                                    body_state,
-                                    ..
-                                } => {
-                                    if effective_width > 0 {
-                                        body_state.render_into(body_textarea, effective_width);
-                                    }
-                                }
-                                _ => {}
-                            }
-                        }
-                        Event::FocusGained if self.config.user_config.git.auto_refresh => {
-                            self.needs_refresh = true;
-                        }
-                        Event::Paste(data) => {
-                            self.handle_paste(data);
-                        }
-                        _ => {}
-                    }
-                }
+                })?;
             }
+
+            // Take everything the reader thread has queued and process it before
+            // the next paint. Holding a navigation key therefore costs one frame
+            // for the whole burst rather than one frame per repeat, which is what
+            // made held keys lag behind and overshoot.
+            let timeout = if animating { ANIMATION_TICK } else { IDLE_TICK };
+            let events = input.wait_batch(timeout);
+            self.handle_event_batch(events);
 
             // Background auto-refresh on refresher.refreshInterval (0 = disabled).
             let refresh_interval = self.config.user_config.refresher.refresh_interval;
@@ -1269,6 +1102,85 @@ impl Gui {
         }
 
         Ok(())
+    }
+
+    /// Apply one batch of terminal events. Any event at all invalidates the
+    /// screen, so the caller repaints once for the whole batch.
+    fn handle_event_batch(&mut self, events: Vec<Event>) {
+        if events.is_empty() {
+            return;
+        }
+        self.needs_redraw = true;
+        for event in events {
+            match event {
+                Event::Key(key) if key.kind == crossterm::event::KeyEventKind::Press => {
+                    if let Err(err) = self.handle_key(key) {
+                        self.show_error("Command failed", err);
+                    }
+                }
+                Event::Mouse(mouse) => self.handle_mouse(mouse),
+                Event::Resize(w, h) => self.handle_resize(w, h),
+                Event::FocusGained if self.config.user_config.git.auto_refresh => {
+                    self.needs_refresh = true;
+                }
+                Event::Paste(data) => self.handle_paste(data),
+                _ => {}
+            }
+            if self.should_quit {
+                // Don't keep acting on a queued burst after a quit: the rest of
+                // the batch was typed before the user knew the app was closing.
+                break;
+            }
+        }
+    }
+
+    fn handle_resize(&mut self, w: u16, h: u16) {
+        self.layout.update_size(w, h);
+        // Re-flow any active commit-message textarea to the new width so
+        // wrapping stays consistent with what the user sees.
+        let popup_width = (w * 60 / 100).clamp(30, 60).min(w);
+        let popup_inner = popup_width.saturating_sub(4) as usize;
+        let config_width = self.config.user_config.git.commit.auto_wrap_width;
+        let effective_width = if config_width > 0 {
+            popup_inner.min(config_width)
+        } else {
+            popup_inner
+        };
+        match &mut self.popup {
+            PopupState::Input {
+                textarea,
+                is_commit: true,
+                ..
+            } => {
+                if effective_width > 0 {
+                    auto_wrap_textarea(textarea, effective_width);
+                }
+            }
+            PopupState::Input {
+                textarea,
+                is_commit: false,
+                ..
+            } => {
+                // Single-line input: re-flow the soft wrap to the new width.
+                let raw: String = textarea.lines().join("");
+                if popup_inner > 0 && !raw.is_empty() {
+                    let mut new_ta = popup::make_textarea("");
+                    new_ta.insert_str(&raw);
+                    soft_wrap_textarea(&mut new_ta, popup_inner);
+                    *textarea = new_ta;
+                }
+            }
+            PopupState::CommitInput {
+                body_textarea,
+                body_state,
+                ..
+            } => {
+                if effective_width > 0 {
+                    body_state.render_into(body_textarea, effective_width);
+                }
+            }
+            _ => {}
+        }
     }
 
     /// Receive completed diff results from the background thread (non-blocking).
@@ -2534,6 +2446,7 @@ impl Gui {
         // Global keybindings
         if matches_key(key, &keybindings.universal.quit)
             || matches_key(key, &keybindings.universal.quit_alt1)
+            || matches_key(key, &keybindings.universal.quit_without_changing_directory)
         {
             self.should_quit = true;
             return Ok(());
@@ -4467,6 +4380,10 @@ impl Gui {
                 HelpEntry {
                     key: kb.universal.quit_alt1.clone(),
                     description: "Quit (alt)".into(),
+                },
+                HelpEntry {
+                    key: kb.universal.quit_without_changing_directory.clone(),
+                    description: "Quit".into(),
                 },
                 HelpEntry {
                     key: kb.universal.return_key.clone(),
@@ -7778,33 +7695,6 @@ mod terminal_mouse_tests {
     }
 
     #[test]
-    fn reconstructs_fragmented_arrow_sequence_without_leaking_amend_shortcut() {
-        assert_eq!(
-            parse_fragmented_escape_sequence("[A"),
-            Some(Event::Key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)))
-        );
-    }
-
-    #[test]
-    fn reconstructs_fragmented_focus_sequence_without_leaking_rebase_shortcut() {
-        assert_eq!(
-            parse_fragmented_escape_sequence("[I"),
-            Some(Event::FocusGained)
-        );
-    }
-
-    #[test]
-    fn reconstructs_fragmented_kitty_command_key_with_its_modifier() {
-        assert_eq!(
-            parse_fragmented_escape_sequence("[49;9u"),
-            Some(Event::Key(KeyEvent::new(
-                KeyCode::Char('1'),
-                KeyModifiers::SUPER
-            )))
-        );
-    }
-
-    #[test]
     fn plain_character_shortcuts_reject_extra_modifiers() {
         assert!(plain_char_key(
             KeyEvent::new(KeyCode::Char('I'), KeyModifiers::SHIFT),
@@ -7952,9 +7842,14 @@ fn setup_terminal() -> Result<(Term, bool)> {
     Ok((terminal, keyboard_enhanced))
 }
 
+/// Put the terminal back the way we found it.
+///
+/// Nothing drains leftover input here: crossterm guards its reader with a
+/// process-wide mutex that the input thread holds for the duration of its
+/// blocking read, so any drain from this thread would silently no-op. The input
+/// thread keeps consuming whatever is queued until the process exits, which is
+/// what the drain was for.
 fn restore_terminal(terminal: &mut Term, keyboard_enhanced: bool) -> Result<()> {
-    drain_pending_terminal_events(Duration::from_millis(0));
-
     if keyboard_enhanced {
         execute!(
             terminal.backend_mut(),
@@ -7977,7 +7872,6 @@ fn restore_terminal(terminal: &mut Term, keyboard_enhanced: bool) -> Result<()> 
     }
     terminal.backend_mut().flush()?;
 
-    drain_pending_terminal_events(Duration::from_millis(25));
     terminal::disable_raw_mode()?;
 
     Ok(())

--- a/src/os/cmd.rs
+++ b/src/os/cmd.rs
@@ -4,6 +4,44 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
 
+/// Detach a child from the controlling terminal and keep it non-interactive.
+///
+/// Every command run through [`CmdBuilder`] has its output captured, so it can
+/// never usefully prompt: whatever it printed would be invisible and whatever it
+/// read would be keystrokes meant for the TUI. That is not hypothetical. A
+/// background `git fetch`/`ls-remote` spawns `ssh`, and `ssh` opens `/dev/tty`
+/// directly — bypassing the null stdin below — to ask for a passphrase. While
+/// one is in flight it races the render loop for terminal input and silently
+/// swallows keypresses, which is what made number keys and `q` unreliable.
+///
+/// `setsid` puts the child in a fresh session with no controlling terminal, so
+/// opening `/dev/tty` fails outright. Note that merely moving it to a new
+/// process group would be worse than doing nothing: a background-group read on
+/// the terminal raises `SIGTTIN`, which would leave the child stopped and the
+/// capturing `wait` hanging forever.
+fn make_non_interactive(cmd: &mut Command) {
+    cmd.env("GIT_TERMINAL_PROMPT", "0");
+    cmd.env("SSH_ASKPASS_REQUIRE", "never");
+    // Only fill in a batch-mode ssh when the user has not chosen their own
+    // command, so custom ssh setups keep working.
+    if std::env::var_os("GIT_SSH_COMMAND").is_none() {
+        cmd.env("GIT_SSH_COMMAND", "ssh -oBatchMode=yes");
+    }
+
+    #[cfg(unix)]
+    // SAFETY: `setsid` is async-signal-safe and touches no allocator or lock
+    // state, which is all `pre_exec` requires of the child between fork and
+    // exec. A freshly forked child is never a process-group leader, so the call
+    // only fails in ways we are content to ignore.
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        cmd.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
+}
+
 /// Shared command log that CmdBuilder writes to when set.
 pub type CommandLog = Arc<Mutex<Vec<String>>>;
 
@@ -131,12 +169,19 @@ impl CmdBuilder {
             cmd.current_dir(cwd);
         }
 
+        // Defaults first, so anything set explicitly on the builder wins.
+        make_non_interactive(&mut cmd);
+
         for (key, value) in &self.env_vars {
             cmd.env(key, value);
         }
 
+        // Never let a child inherit the TUI's stdin: the terminal is in raw mode
+        // and shared with the render loop.
         if self.stdin_data.is_some() {
             cmd.stdin(Stdio::piped());
+        } else {
+            cmd.stdin(Stdio::null());
         }
 
         cmd.stdout(Stdio::piped());


### PR DESCRIPTION
Number keys not switching panels, `q` not quitting, held `j`/`k` lagging, and the interactive-rebase dialog opening by itself on Ghostty tab switches turned out to be **three separate causes**. Each was reproduced and measured with a PTY harness that emulates Ghostty (answering the kitty-keyboard and DA1 capability queries), so the numbers below are before/after on the same driver.

## 1. Background git was stealing keystrokes

The big one. `git fetch --all` / `git ls-remote` spawn `ssh`, and `ssh` opens `/dev/tty` **directly** — so a null stdin does not stop it. It printed its passphrase prompt over the TUI and read the user's keypresses as the passphrase. Driving the old binary, pressing `3 3 3 4 4 2 2 1`:

```
key 3  hint="Enter passphrase for key '/Users/…/.ssh/id_ed25519':   tab/1-5 p"
key 3  hint="En new  d delate  P pusy 'qUqeit/jtab/1-5.panels_ej/k nav"
```

That garbled line is both the "random characters" and the dead number keys: while a fetch was in flight, 1 in 3 keypresses never reached the app.

Every command run through `CmdBuilder` has its output captured, so none of them can usefully prompt. They now run in a fresh session via `setsid` (which makes opening `/dev/tty` fail outright) with non-interactive git/ssh env. A user's own `GIT_SSH_COMMAND` is left alone.

Worth noting: a new *process group* would be worse than doing nothing — a background-group read on the terminal raises `SIGTTIN`, leaving the child stopped and the capturing `wait` hung forever. It has to be a new *session*.

**5/5 keypresses delivered, up from 1–3/5.**

## 2. Escape sequences leaked as shortcuts

Input was read once per rendered frame. When a PTY read ended after the initial `ESC` (crossterm-rs/crossterm#993), the tail sat unread until the next frame — 20–50ms later, past the old 25ms reassembly window. Ghostty's focus report on Cmd+N therefore decayed into `Esc`, `[`, `I`, and `I` opened the interactive rebase picker while the rest was typed into the UI.

Input now lives in `src/gui/input.rs` on a thread that blocks on `event::read()`, so a fragmented tail arrives in microseconds. Reassembly validates the CSI grammar: a partial sequence is dropped rather than replayed as keypresses, while a character that cannot belong to the sequence is still delivered as the key it is — `ESC [ q` must not eat quit. The continuation probe is short enough that a real `Esc` is no longer delayed (it was effectively a full frame + 25ms before).

## 3. Held keys lagged and overshot

Auto-repeat delivers keys faster than a full repaint, and processing one key per frame let the queue grow without bound, so navigation kept scrolling after release. The loop now takes whole batches and paints once.

**A 200-key burst settles in 0.03s, was 0.53s — and is now flat rather than scaling with backlog.**

The loop also paints only when something changed (500ms backstop so a missed invalidation self-corrects), and the spinner is driven from elapsed time so its speed no longer tracks frame rate. **Idle render cost: 3–5% of a core → ~0%.**

## Also

`quitWithoutChangingDirectory` (`Q`) was defined in the keybinding config but never handled — now wired up and listed in `?`.

## Notes for review

- **Behaviour change:** with batch-mode ssh, a passphrase-protected key that is not in the agent makes push/pull fail fast with "Permission denied" instead of prompting. That prompt was never usable — it drew under the TUI and stole input — but there is no credential-prompt UI yet, so this is a deliberate trade rather than a strict win.
- Escape reassembly covers splits up to 15ms; a pathological longer split still falls back to raw keys. I sized that to keep `Esc` feeling instant rather than tuning it to pass a synthetic test.
- `libc` is added (unix-only) for `setsid`; there is no way to get a new session from `std`.
- 66 tests pass, 14 of them new for the reassembler (split focus report, truncated sequence dropped, real keys never swallowed, control strings, SS3, modifier decoding). `9f20500` builds standalone so the history bisects cleanly.
