### PR TITLE
feat(perf): discard performance #25

### DIFF
--- a/src/git/file.rs
+++ b/src/git/file.rs
@@ -190,21 +190,109 @@ impl GitCommands {
 
     pub fn discard_file(&self, path: &str, added: bool) -> Result<()> {
         // Unstage first if needed (ignore errors — file may not be staged)
-        let _ = self.git().args(&["reset", "HEAD", "--", path]).run();
+        let _ = self
+            .git()
+            .args(&["--literal-pathspecs", "reset", "HEAD", "--", path])
+            .run();
 
         if added {
-            // New/untracked file: just delete it
-            let full_path = self.repo_path().join(path);
-            if full_path.is_dir() {
-                std::fs::remove_dir_all(&full_path)?;
-            } else {
-                std::fs::remove_file(&full_path)?;
-            }
+            self.remove_worktree_path(path)?;
         } else {
             // Tracked file: discard working tree changes
             self.git()
-                .args(&["checkout", "--", path])
+                .args(&["--literal-pathspecs", "checkout", "--", path])
                 .run_expecting_success()?;
+        }
+        Ok(())
+    }
+
+    /// Discard many files in a few git calls instead of one process per path.
+    ///
+    /// Mirrors lazygit `DiscardAllDirChanges`: bucket into reset / checkout /
+    /// remove, then run each git command on path batches under ARG_MAX.
+    pub fn discard_files(&self, files: &[File]) -> Result<()> {
+        if files.is_empty() {
+            return Ok(());
+        }
+        if files.len() == 1 {
+            let file = &files[0];
+            return self.discard_file(file.current_path(), file.added);
+        }
+
+        let mut special_files = Vec::new();
+        let mut files_to_reset = Vec::new();
+        let mut files_to_checkout = Vec::new();
+        let mut files_to_remove = Vec::new();
+
+        for file in files {
+            let path = file.current_path().to_string();
+            // Renames and certain merge-conflict statuses need per-file logic.
+            if file.rename_paths().is_some()
+                || file.short_status == "AA"
+                || file.short_status == "DU"
+            {
+                special_files.push(file);
+                continue;
+            }
+
+            if file.has_staged_changes || file.has_merge_conflicts {
+                files_to_reset.push(path.clone());
+                if file.short_status == "DD" || file.short_status == "AU" {
+                    continue;
+                }
+                if file.added {
+                    files_to_remove.push(path);
+                } else {
+                    files_to_checkout.push(path);
+                }
+                continue;
+            }
+
+            if file.short_status == "DD" || file.short_status == "AU" {
+                continue;
+            }
+
+            if file.added {
+                files_to_remove.push(path);
+            } else {
+                files_to_checkout.push(path);
+            }
+        }
+
+        for file in special_files {
+            self.discard_file(file.current_path(), file.added)?;
+        }
+
+        self.run_git_on_paths(&["reset", "HEAD"], &files_to_reset)?;
+        for path in &files_to_remove {
+            self.remove_worktree_path(path)?;
+        }
+        self.run_git_on_paths(&["checkout"], &files_to_checkout)
+    }
+
+    fn remove_worktree_path(&self, path: &str) -> Result<()> {
+        let full_path = self.repo_path().join(path);
+        if full_path.is_dir() {
+            std::fs::remove_dir_all(&full_path)?;
+        } else if full_path.exists() {
+            std::fs::remove_file(&full_path)?;
+        }
+        Ok(())
+    }
+
+    /// Run `git <subcommand> -- <paths...>`, splitting to stay under ARG_MAX.
+    /// Windows CreateProcess is ~32 KB; 30 KB matches lazygit's threshold.
+    fn run_git_on_paths(&self, subcommand: &[&str], paths: &[String]) -> Result<()> {
+        if paths.is_empty() {
+            return Ok(());
+        }
+        for chunk in chunk_paths(paths, MAX_GIT_PATH_ARG_BYTES) {
+            let mut args = Vec::with_capacity(1 + subcommand.len() + 1 + chunk.len());
+            args.push("--literal-pathspecs");
+            args.extend(subcommand.iter().copied());
+            args.push("--");
+            args.extend(chunk.iter().map(String::as_str));
+            self.git().args(&args).run_expecting_success()?;
         }
         Ok(())
     }
@@ -299,7 +387,194 @@ pub(super) fn parse_hunk_counts(output: &str) -> HashMap<String, usize> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use super::*;
+
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new(prefix: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time before unix epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "lazygitrs-{prefix}-{unique}-{}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&path).expect("create temp dir");
+            Self { path }
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn git(repo: &Path, args: &[&str]) {
+        assert!(
+            Command::new("git")
+                .args(args)
+                .current_dir(repo)
+                .status()
+                .expect("run git command")
+                .success()
+        );
+    }
+
+    fn init_repo(path: &Path) {
+        git(path, &["init", "-q"]);
+        git(path, &["config", "user.email", "test@example.com"]);
+        git(path, &["config", "user.name", "Test"]);
+    }
+
+    fn seed_tracked_files(repo: &Path, n: usize) {
+        std::fs::create_dir_all(repo.join("src")).expect("mkdir src");
+        for i in 0..n {
+            std::fs::write(repo.join("src").join(format!("f{i}.txt")), "original\n")
+                .expect("write tracked file");
+        }
+        git(repo, &["add", "."]);
+        git(repo, &["commit", "-qm", "init"]);
+        for i in 0..n {
+            std::fs::write(repo.join("src").join(format!("f{i}.txt")), "changed\n")
+                .expect("modify tracked file");
+        }
+    }
+
+    fn porcelain_paths(repo: &Path) -> Vec<String> {
+        let output = Command::new("git")
+            .args(["status", "--porcelain", "-uall"])
+            .current_dir(repo)
+            .output()
+            .expect("git status");
+        assert!(output.status.success());
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter(|line| line.len() >= 4)
+            .map(|line| line[3..].to_string())
+            .collect()
+    }
+
+    #[test]
+    fn chunk_paths_splits_on_arg_max() {
+        let long = |ch: char| ch.to_string().repeat(9_000);
+        let p1 = long('a');
+        let p2 = long('b');
+        let p3 = long('c');
+        let p4 = long('d');
+
+        assert!(chunk_paths(&[], 30_000).is_empty());
+
+        let fit_paths = [p1.clone(), p2.clone(), p3.clone()];
+        let fit = chunk_paths(&fit_paths, 30_000);
+        assert_eq!(fit.len(), 1);
+        assert_eq!(fit[0].len(), 3);
+
+        let split_paths = [p1, p2, p3, p4];
+        let split = chunk_paths(&split_paths, 30_000);
+        assert_eq!(split.len(), 2);
+        assert_eq!(split[0].len(), 3);
+        assert_eq!(split[1].len(), 1);
+    }
+
+    #[test]
+    fn discard_files_handles_mixed_added_staged_and_modified() {
+        let temp = TempDir::new("discard-mixed");
+        let repo = &temp.path;
+        init_repo(repo);
+
+        std::fs::write(repo.join("tracked.txt"), "original\n").expect("write");
+        std::fs::write(repo.join("staged.txt"), "original\n").expect("write");
+        std::fs::write(repo.join("both.txt"), "original\n").expect("write");
+        git(repo, &["add", "."]);
+        git(repo, &["commit", "-qm", "init"]);
+
+        std::fs::write(repo.join("tracked.txt"), "changed\n").expect("modify");
+        std::fs::write(repo.join("staged.txt"), "changed\n").expect("modify");
+        git(repo, &["add", "staged.txt"]);
+        std::fs::write(repo.join("both.txt"), "staged\n").expect("modify");
+        git(repo, &["add", "both.txt"]);
+        std::fs::write(repo.join("both.txt"), "unstaged\n").expect("modify");
+        std::fs::write(repo.join("untracked.txt"), "new\n").expect("write untracked");
+        std::fs::write(repo.join("added.txt"), "added\n").expect("write added");
+        git(repo, &["add", "added.txt"]);
+
+        let git_cmds = GitCommands::new(repo).expect("git");
+        let files = git_cmds.load_files_status_only().expect("status");
+        assert_eq!(files.len(), 5);
+        git_cmds.discard_files(&files).expect("discard");
+
+        assert!(porcelain_paths(repo).is_empty());
+        assert_eq!(
+            std::fs::read_to_string(repo.join("tracked.txt")).unwrap(),
+            "original\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(repo.join("staged.txt")).unwrap(),
+            "original\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(repo.join("both.txt")).unwrap(),
+            "original\n"
+        );
+        assert!(!repo.join("untracked.txt").exists());
+        assert!(!repo.join("added.txt").exists());
+    }
+
+    #[test]
+    fn discard_files_is_faster_than_per_file_on_large_changeset() {
+        const N: usize = 120;
+        let sequential_temp = TempDir::new("discard-seq");
+        let batched_temp = TempDir::new("discard-batch");
+        init_repo(&sequential_temp.path);
+        init_repo(&batched_temp.path);
+        seed_tracked_files(&sequential_temp.path, N);
+        seed_tracked_files(&batched_temp.path, N);
+
+        let sequential_git = GitCommands::new(&sequential_temp.path).expect("git");
+        let sequential_files = sequential_git.load_files_status_only().expect("status");
+        assert_eq!(sequential_files.len(), N);
+        let sequential_start = std::time::Instant::now();
+        for file in &sequential_files {
+            sequential_git
+                .discard_file(file.current_path(), file.added)
+                .expect("discard_file");
+        }
+        let sequential = sequential_start.elapsed();
+
+        let batched_git = GitCommands::new(&batched_temp.path).expect("git");
+        let batched_files = batched_git.load_files_status_only().expect("status");
+        assert_eq!(batched_files.len(), N);
+        let batched_start = std::time::Instant::now();
+        batched_git
+            .discard_files(&batched_files)
+            .expect("discard_files");
+        let batched = batched_start.elapsed();
+
+        eprintln!(
+            "discard {N} files: sequential={sequential:?} batched={batched:?} ({:.1}x)",
+            sequential.as_secs_f64() / batched.as_secs_f64().max(0.000_001)
+        );
+
+        assert!(porcelain_paths(&sequential_temp.path).is_empty());
+        assert!(porcelain_paths(&batched_temp.path).is_empty());
+        assert!(
+            batched < sequential,
+            "batched discard should beat per-file git spawn: sequential={sequential:?} batched={batched:?}"
+        );
+        assert!(
+            batched.as_secs() < 3,
+            "batched discard too slow on {N} files: {batched:?}"
+        );
+    }
 
     #[test]
     fn parses_numstat_for_regular_renamed_and_binary_files() {
@@ -328,6 +603,29 @@ mod tests {
         assert_eq!(counts.get("new.rs"), Some(&1));
         assert_eq!(counts.get("removed.rs"), Some(&1));
     }
+}
+
+/// Windows CreateProcess is ~32 KB; match lazygit's 30 KB path-batch limit.
+const MAX_GIT_PATH_ARG_BYTES: usize = 30_000;
+
+/// Split `paths` into batches whose joined length stays under `max_arg_bytes`.
+fn chunk_paths(paths: &[String], max_arg_bytes: usize) -> Vec<&[String]> {
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < paths.len() {
+        let mut end = start;
+        let mut total = 0;
+        while end < paths.len() {
+            total += paths[end].len() + 1; // +1 for the separating space
+            if total > max_arg_bytes && end > start {
+                break;
+            }
+            end += 1;
+        }
+        chunks.push(&paths[start..end]);
+        start = end;
+    }
+    chunks
 }
 
 /// Decode a path as emitted by `git status --porcelain`.

--- a/src/gui/controller/files.rs
+++ b/src/gui/controller/files.rs
@@ -734,24 +734,19 @@ fn discard_file(gui: &mut Gui) -> Result<()> {
             if node.is_dir {
                 let child_indices = node.child_file_indices.clone();
                 let model = gui.model.lock().unwrap();
-                let files_info: Vec<(String, bool)> = child_indices
+                let files: Vec<_> = child_indices
                     .iter()
-                    .filter_map(|&i| {
-                        model
-                            .files
-                            .get(i)
-                            .map(|f| (f.current_path().to_string(), f.added))
-                    })
+                    .filter_map(|&i| model.files.get(i).cloned())
                     .collect();
                 let dir_name = node.name.clone();
                 drop(model);
 
-                if files_info.is_empty() {
+                if files.is_empty() {
                     return Ok(());
                 }
 
                 if !gui.config.user_config.gui.skip_discard_change_warning {
-                    let files_info_clone = files_info.clone();
+                    let files_clone = files.clone();
                     gui.popup = PopupState::Menu {
                         title: format!("Discard all changes in '{}'?", dir_name),
                         items: vec![
@@ -760,9 +755,7 @@ fn discard_file(gui: &mut Gui) -> Result<()> {
                                 description: "discard all changes".to_string(),
                                 key: Some("d".to_string()),
                                 action: Some(Box::new(move |gui| {
-                                    for (name, added) in &files_info_clone {
-                                        gui.git.discard_file(name, *added)?;
-                                    }
+                                    gui.git.discard_files(&files_clone)?;
                                     gui.needs_refresh = true;
                                     Ok(())
                                 })),
@@ -778,9 +771,7 @@ fn discard_file(gui: &mut Gui) -> Result<()> {
                         loading_index: None,
                     };
                 } else {
-                    for (name, added) in &files_info {
-                        gui.git.discard_file(name, *added)?;
-                    }
+                    gui.git.discard_files(&files)?;
                     gui.needs_refresh = true;
                 }
                 return Ok(());


### PR DESCRIPTION
## Summary

Fixes #25: discarding a directory with a large changeset froze the UI because each file spawned its own `git reset` + `git checkout`.

Directory discard now matches lazygit (`DiscardAllDirChanges` + `runGitCmdOnPaths`):

- Bucket files into reset / checkout / remove
- Run each git command on path batches under ARG_MAX (30 KB)
- Fall back to per-file discard for renames and a couple of merge-conflict statuses (`AA`, `DU`)
- Pass `--literal-pathspecs` so glob-looking names are not expanded

Single-file `d` is unchanged (already one process).

## Measurements

120 tracked files, `cargo test discard_files_is_faster -- --nocapture`:

| Path | Time |
|---|---|
| Per-file `discard_file` | ~2.4s |
| Batched `discard_files` | ~33ms (~73×) |

Manual smoke: 400-file prettier-style rewrite, select `.` → `d` → Discard. UI stays responsive.

## Test plan

- [x] `cargo test discard` — mixed statuses (unstaged / staged / both / untracked / added) + ARG_MAX chunking + sequential vs batched
- [x] Manual: bulk discard on a large dirty tree

## Merge confidence: 86

Small, lazygit-aligned change with tests and a smoked happy path. Residual risk is merge-conflict / rename buckets, which still take the old per-file path rather than the new batcher.