### PR TITLE
feat(hunk-staging-2): separator-stacked staged/unstaged diff

### DIFF
--- a/src/git/staging.rs
+++ b/src/git/staging.rs
@@ -100,6 +100,44 @@ impl GitCommands {
             .with_context(|| format!("failed to revert hunk in {}", file_path))?;
         Ok(())
     }
+
+    /// Stage only the lines of a single visual change block by applying a
+    /// sub-patch sliced from the unstaged (`git diff`) `unified_diff` to the
+    /// index (`git apply --cached`).
+    pub fn stage_visual_block(
+        &self,
+        file_path: &str,
+        unified_diff: &str,
+        want_old: Option<(usize, usize)>,
+        want_new: Option<(usize, usize)>,
+    ) -> Result<()> {
+        let patch = build_visual_block_patch(file_path, unified_diff, want_old, want_new)?;
+        self.git()
+            .args(&["apply", "--cached", "--unidiff-zero", "-"])
+            .stdin(patch)
+            .run_expecting_success()
+            .with_context(|| format!("failed to stage hunk in {}", file_path))?;
+        Ok(())
+    }
+
+    /// Unstage only the lines of a single visual change block by
+    /// reverse-applying a sub-patch sliced from the staged
+    /// (`git diff --cached`) `unified_diff` to the index.
+    pub fn unstage_visual_block(
+        &self,
+        file_path: &str,
+        unified_diff: &str,
+        want_old: Option<(usize, usize)>,
+        want_new: Option<(usize, usize)>,
+    ) -> Result<()> {
+        let patch = build_visual_block_patch(file_path, unified_diff, want_old, want_new)?;
+        self.git()
+            .args(&["apply", "--cached", "--reverse", "--unidiff-zero", "-"])
+            .stdin(patch)
+            .run_expecting_success()
+            .with_context(|| format!("failed to unstage hunk in {}", file_path))?;
+        Ok(())
+    }
 }
 
 fn build_visual_block_patch(

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2959,20 +2959,19 @@ impl Gui {
                     self.diff_loading_since = Some(Instant::now());
                     self.queue_diff_job(generation, diff_key, move || {
                         let path_refs: Vec<&str> = diff_paths.iter().map(String::as_str).collect();
-                        // Both sides staged: one HEAD buffer with coherent
-                        // line numbers; hunks are tinted staged/unstaged via
-                        // overlap with the unstaged diff. Falls back to the
-                        // unstaged-only view when HEAD is unavailable
-                        // (e.g. unborn HEAD).
+                        // Both sides present: one buffer with unstaged
+                        // hunks on top, a `Staged changes` separator, then
+                        // staged hunks. Falls back to the single-side view
+                        // when a side is unavailable.
                         if has_unstaged && has_staged {
                             let exists = git.repo_path().join(&current_path).exists();
                             match (
-                                git.diff_paths_vs_head(&path_refs),
                                 git.diff_file_paths(&path_refs),
+                                git.diff_file_staged_paths(&path_refs),
                             ) {
-                                (Ok(head), Ok(unstaged)) => {
-                                    let parsed = DiffViewState::parse_head_with_staged(
-                                        &name, &head, &unstaged, 4, exists,
+                                (Ok(unstaged), Ok(staged)) => {
+                                    let parsed = DiffViewState::parse_combined_file_diff(
+                                        &name, &unstaged, &staged, 4, exists,
                                     );
                                     if parsed.lines.is_empty() {
                                         DiffPayload::Empty
@@ -3070,10 +3069,16 @@ impl Gui {
                                     Some(p) => vec![p],
                                     None => Vec::new(),
                                 };
-                                let mut combined_diff =
-                                    git.diff_paths_vs_head(&paths).unwrap_or_default();
+                                // Directory hover: unstaged multi-file diff on
+                                // top, a `Staged changes` separator, then the
+                                // staged multi-file diff — same stacking as
+                                // the single-file view. Untracked children
+                                // only exist unstaged. Hunk actions stay
+                                // Cancel-only here (no single file to act on).
                                 let mut unstaged_combined =
                                     git.diff_file_paths(&paths).unwrap_or_default();
+                                let staged_combined =
+                                    git.diff_staged_paths(&paths).unwrap_or_default();
                                 for path in &untracked {
                                     if gen_counter.load(Ordering::Relaxed) != generation {
                                         return DiffPayload::Empty;
@@ -3087,37 +3092,43 @@ impl Gui {
                                         }
                                         synthesize_new_file_diff(path, &content)
                                     };
-                                    if !combined_diff.is_empty() {
-                                        combined_diff.push('\n');
-                                    }
-                                    combined_diff.push_str(&synth);
-                                    // Mirror the synthesized section so the
-                                    // untracked file classifies as unstaged.
                                     if !unstaged_combined.is_empty() {
                                         unstaged_combined.push('\n');
                                     }
                                     unstaged_combined.push_str(&synth);
                                 }
 
-                                if combined_diff.is_empty() {
+                                if unstaged_combined.trim().is_empty()
+                                    && staged_combined.trim().is_empty()
+                                {
                                     DiffPayload::Empty
                                 } else {
-                                    use crate::pager::side_by_side::head_block_staged_flags;
-                                    let mut parsed = DiffViewState::parse_diff_output(
+                                    use crate::pager::side_by_side::DiffViewState as DVS;
+                                    let mut unstaged_parsed = DVS::parse_diff_output(
                                         &dir_name,
-                                        &combined_diff,
+                                        &unstaged_combined,
                                         4,
                                         true,
                                     );
-                                    parsed.hunk_staged = head_block_staged_flags(
-                                        &combined_diff,
-                                        &unstaged_combined,
+                                    unstaged_parsed.hunk_staged =
+                                        vec![false; unstaged_parsed.hunk_starts.len()];
+                                    let mut staged_parsed = DVS::parse_diff_output(
+                                        &dir_name,
+                                        &staged_combined,
                                         4,
+                                        true,
                                     );
-                                    if parsed.hunk_staged.len() != parsed.hunk_starts.len() {
-                                        parsed.hunk_staged = vec![false; parsed.hunk_starts.len()];
+                                    staged_parsed.hunk_staged =
+                                        vec![true; staged_parsed.hunk_starts.len()];
+                                    let parsed = DVS::combine_parsed_with_separator(
+                                        unstaged_parsed,
+                                        staged_parsed,
+                                    );
+                                    if parsed.lines.is_empty() {
+                                        DiffPayload::Empty
+                                    } else {
+                                        DiffPayload::Parsed(parsed)
                                     }
-                                    DiffPayload::Parsed(parsed)
                                 }
                             });
                         } else {
@@ -7810,39 +7821,6 @@ impl Gui {
         };
     }
 
-    /// Match the viewed HEAD block against the blocks of a freshly fetched
-    /// per-side diff, returning their slice ranges for patch building.
-    /// Matching runs on the side both diffs share (worktree for unstaged,
-    /// HEAD for staged) so staged edits elsewhere in the file can't shift
-    /// the mapping. Sorted deepest-first so sequential applies don't shift
-    /// the line numbers of pending ones.
-    fn matching_side_blocks(
-        &self,
-        hunk_idx: usize,
-        side_diff: &str,
-        new_side: bool,
-    ) -> Vec<(Option<(usize, usize)>, Option<(usize, usize)>)> {
-        let view_spans =
-            DiffViewState::block_spans(&self.diff_view.lines, &self.diff_view.hunk_line_offsets);
-        let Some(view) = view_spans.get(hunk_idx) else {
-            return Vec::new();
-        };
-        let mut matched: Vec<(usize, Option<(usize, usize)>, Option<(usize, usize)>)> =
-            DiffViewState::block_spans_for_diff(side_diff, 4)
-                .into_iter()
-                .filter(|s| view.overlaps(s, new_side))
-                .map(|s| {
-                    let anchor = s.old.map(|(lo, _)| lo).unwrap_or(s.old_point);
-                    (anchor, s.old, s.new)
-                })
-                .collect();
-        matched.sort_by(|a, b| b.0.cmp(&a.0));
-        matched
-            .into_iter()
-            .map(|(_, old, new)| (old, new))
-            .collect()
-    }
-
     fn stage_selected_file_hunk(&mut self, hunk_idx: usize) -> Result<()> {
         let Some(file_idx) = self.selected_file_index() else {
             return Ok(());
@@ -7852,6 +7830,15 @@ impl Gui {
             return Ok(());
         };
         drop(model);
+
+        // Each stacked section keeps its own side's line numbers, so the
+        // viewed hunk's ranges slice the unstaged diff directly.
+        let Some((want_old, want_new)) = self.diff_view.visual_block_line_ranges(hunk_idx) else {
+            return Ok(());
+        };
+        if want_old.is_none() && want_new.is_none() {
+            return Ok(());
+        }
 
         let path_refs: Vec<String> = file.diff_paths().into_iter().map(str::to_string).collect();
         let refs: Vec<&str> = path_refs.iter().map(String::as_str).collect();
@@ -7867,25 +7854,8 @@ impl Gui {
             return Ok(());
         }
 
-        // The view may be a HEAD buffer, so map the hunk onto the unstaged
-        // diff's blocks via the shared worktree side.
-        let targets = self.matching_side_blocks(hunk_idx, &diff, true);
-        if targets.is_empty() {
-            self.popup = PopupState::Message {
-                title: "Stage hunk".to_string(),
-                message: "That hunk moved — the diff was refreshed.".to_string(),
-                kind: MessageKind::Info,
-            };
-            self.needs_diff_refresh = true;
-            return Ok(());
-        }
-        for (want_old, want_new) in targets {
-            if want_old.is_none() && want_new.is_none() {
-                continue;
-            }
-            self.git
-                .stage_visual_block(file.current_path(), &diff, want_old, want_new)?;
-        }
+        self.git
+            .stage_visual_block(file.current_path(), &diff, want_old, want_new)?;
         self.needs_files_refresh = true;
         self.needs_diff_refresh = true;
         Ok(())
@@ -7901,6 +7871,15 @@ impl Gui {
         };
         drop(model);
 
+        // The staged section keeps staged line numbers, so the viewed
+        // hunk's ranges slice the staged diff directly.
+        let Some((want_old, want_new)) = self.diff_view.visual_block_line_ranges(hunk_idx) else {
+            return Ok(());
+        };
+        if want_old.is_none() && want_new.is_none() {
+            return Ok(());
+        }
+
         let path_refs: Vec<String> = file.diff_paths().into_iter().map(str::to_string).collect();
         let refs: Vec<&str> = path_refs.iter().map(String::as_str).collect();
         let diff = self.git.diff_file_staged_paths(&refs)?;
@@ -7908,25 +7887,8 @@ impl Gui {
             return Ok(());
         }
 
-        // The view may be a HEAD buffer, so map the hunk onto the staged
-        // diff's blocks via the shared HEAD side.
-        let targets = self.matching_side_blocks(hunk_idx, &diff, false);
-        if targets.is_empty() {
-            self.popup = PopupState::Message {
-                title: "Unstage hunk".to_string(),
-                message: "That hunk moved — the diff was refreshed.".to_string(),
-                kind: MessageKind::Info,
-            };
-            self.needs_diff_refresh = true;
-            return Ok(());
-        }
-        for (want_old, want_new) in targets {
-            if want_old.is_none() && want_new.is_none() {
-                continue;
-            }
-            self.git
-                .unstage_visual_block(file.current_path(), &diff, want_old, want_new)?;
-        }
+        self.git
+            .unstage_visual_block(file.current_path(), &diff, want_old, want_new)?;
         self.needs_files_refresh = true;
         self.needs_diff_refresh = true;
         Ok(())
@@ -7954,21 +7916,17 @@ impl Gui {
         let file_name = file.name.clone();
         drop(model);
 
-        let diff = self.git.diff_file(&file_name)?;
-        if diff.is_empty() {
+        // Revert is only offered on unstaged hunks, whose ranges slice the
+        // unstaged diff directly.
+        let Some((want_old, want_new)) = self.diff_view.visual_block_line_ranges(hunk_idx) else {
+            return Ok(());
+        };
+        if want_old.is_none() && want_new.is_none() {
             return Ok(());
         }
 
-        // The view may be a HEAD buffer, so map the hunk onto the unstaged
-        // diff's blocks via the shared worktree side.
-        let targets = self.matching_side_blocks(hunk_idx, &diff, true);
-        if targets.is_empty() {
-            self.popup = PopupState::Message {
-                title: "Revert block".to_string(),
-                message: "That hunk moved — the diff was refreshed.".to_string(),
-                kind: MessageKind::Info,
-            };
-            self.needs_diff_refresh = true;
+        let diff = self.git.diff_file(&file_name)?;
+        if diff.is_empty() {
             return Ok(());
         }
 
@@ -7978,13 +7936,8 @@ impl Gui {
         let abs_path = self.git.repo_path().join(&file_name);
         let pre_bytes = std::fs::read(&abs_path).ok();
 
-        for (want_old, want_new) in targets {
-            if want_old.is_none() && want_new.is_none() {
-                continue;
-            }
-            self.git
-                .revert_visual_block_in_worktree(&file_name, &diff, want_old, want_new)?;
-        }
+        self.git
+            .revert_visual_block_in_worktree(&file_name, &diff, want_old, want_new)?;
 
         if let Some(bytes) = pre_bytes {
             let stack = &mut self.diff_view.revert_undo_stack;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2959,49 +2959,85 @@ impl Gui {
                     self.diff_loading_since = Some(Instant::now());
                     self.queue_diff_job(generation, diff_key, move || {
                         let path_refs: Vec<&str> = diff_paths.iter().map(String::as_str).collect();
-                        let diff_result = if has_unstaged {
-                            git.diff_file_paths(&path_refs)
-                        } else if has_staged {
-                            git.diff_file_staged_paths(&path_refs)
-                        } else {
-                            Ok(String::new())
-                        };
-
-                        let exists = git.repo_path().join(&current_path).exists();
-                        match diff_result {
-                            Ok(diff) if diff.is_empty() && !tracked => {
-                                if git.is_binary_path(&current_path) {
-                                    DiffPayload::Parsed(DiffViewState::parse_diff_output(
-                                        &current_path,
-                                        &synthesize_binary_file_diff(&current_path),
-                                        4,
-                                        exists,
-                                    ))
-                                } else {
-                                    match git.file_content(&current_path) {
-                                        Ok(content) if !content.is_empty() => {
-                                            DiffPayload::Parsed(DiffViewState::parse_content(
-                                                &current_path,
-                                                "",
-                                                &content,
-                                                4,
-                                                exists,
-                                            ))
-                                        }
-                                        _ => DiffPayload::Empty,
+                        // Both sides staged: one HEAD buffer with coherent
+                        // line numbers; hunks are tinted staged/unstaged via
+                        // overlap with the unstaged diff. Falls back to the
+                        // unstaged-only view when HEAD is unavailable
+                        // (e.g. unborn HEAD).
+                        if has_unstaged && has_staged {
+                            let exists = git.repo_path().join(&current_path).exists();
+                            match (
+                                git.diff_paths_vs_head(&path_refs),
+                                git.diff_file_paths(&path_refs),
+                            ) {
+                                (Ok(head), Ok(unstaged)) => {
+                                    let parsed = DiffViewState::parse_head_with_staged(
+                                        &name, &head, &unstaged, 4, exists,
+                                    );
+                                    if parsed.lines.is_empty() {
+                                        DiffPayload::Empty
+                                    } else {
+                                        DiffPayload::Parsed(parsed)
                                     }
                                 }
+                                _ => DiffPayload::Empty,
                             }
-                            Ok(diff) if diff.is_empty() => DiffPayload::Empty,
-                            Ok(diff) => parse_file_diff_payload(
-                                &git,
-                                &name,
-                                &current_path,
-                                &diff,
-                                exists,
-                                has_staged && !has_unstaged,
-                            ),
-                            Err(_) => DiffPayload::Empty,
+                        } else {
+                            let diff_result = if has_unstaged {
+                                git.diff_file_paths(&path_refs)
+                            } else if has_staged {
+                                git.diff_file_staged_paths(&path_refs)
+                            } else {
+                                Ok(String::new())
+                            };
+
+                            let exists = git.repo_path().join(&current_path).exists();
+                            match diff_result {
+                                Ok(diff) if diff.is_empty() && !tracked => {
+                                    if git.is_binary_path(&current_path) {
+                                        DiffPayload::Parsed(DiffViewState::parse_diff_output(
+                                            &current_path,
+                                            &synthesize_binary_file_diff(&current_path),
+                                            4,
+                                            exists,
+                                        ))
+                                    } else {
+                                        match git.file_content(&current_path) {
+                                            Ok(content) if !content.is_empty() => {
+                                                DiffPayload::Parsed(DiffViewState::parse_content(
+                                                    &current_path,
+                                                    "",
+                                                    &content,
+                                                    4,
+                                                    exists,
+                                                ))
+                                            }
+                                            _ => DiffPayload::Empty,
+                                        }
+                                    }
+                                }
+                                Ok(diff) if diff.is_empty() => DiffPayload::Empty,
+                                Ok(diff) => {
+                                    let mut payload = parse_file_diff_payload(
+                                        &git,
+                                        &name,
+                                        &current_path,
+                                        &diff,
+                                        exists,
+                                        has_staged && !has_unstaged,
+                                    );
+                                    // Staged-only view: every visible hunk is
+                                    // staged, so tint + menu must reflect that.
+                                    if has_staged && !has_unstaged {
+                                        if let DiffPayload::Parsed(ref mut parsed) = payload {
+                                            parsed.hunk_staged =
+                                                vec![true; parsed.hunk_starts.len()];
+                                        }
+                                    }
+                                    payload
+                                }
+                                Err(_) => DiffPayload::Empty,
+                            }
                         }
                     });
                 } else if self.show_file_tree {
@@ -3036,6 +3072,8 @@ impl Gui {
                                 };
                                 let mut combined_diff =
                                     git.diff_paths_vs_head(&paths).unwrap_or_default();
+                                let mut unstaged_combined =
+                                    git.diff_file_paths(&paths).unwrap_or_default();
                                 for path in &untracked {
                                     if gen_counter.load(Ordering::Relaxed) != generation {
                                         return DiffPayload::Empty;
@@ -3053,17 +3091,33 @@ impl Gui {
                                         combined_diff.push('\n');
                                     }
                                     combined_diff.push_str(&synth);
+                                    // Mirror the synthesized section so the
+                                    // untracked file classifies as unstaged.
+                                    if !unstaged_combined.is_empty() {
+                                        unstaged_combined.push('\n');
+                                    }
+                                    unstaged_combined.push_str(&synth);
                                 }
 
                                 if combined_diff.is_empty() {
                                     DiffPayload::Empty
                                 } else {
-                                    DiffPayload::Parsed(DiffViewState::parse_diff_output(
+                                    use crate::pager::side_by_side::head_block_staged_flags;
+                                    let mut parsed = DiffViewState::parse_diff_output(
                                         &dir_name,
                                         &combined_diff,
                                         4,
                                         true,
-                                    ))
+                                    );
+                                    parsed.hunk_staged = head_block_staged_flags(
+                                        &combined_diff,
+                                        &unstaged_combined,
+                                        4,
+                                    );
+                                    if parsed.hunk_staged.len() != parsed.hunk_starts.len() {
+                                        parsed.hunk_staged = vec![false; parsed.hunk_starts.len()];
+                                    }
+                                    DiffPayload::Parsed(parsed)
                                 }
                             });
                         } else {
@@ -7674,13 +7728,7 @@ impl Gui {
             return false;
         };
         self.diff_view.selected_revert_hunk = Some(hunk_idx);
-        if let Err(err) = self.revert_selected_file_hunk(hunk_idx) {
-            self.popup = PopupState::Message {
-                title: "Revert block failed".to_string(),
-                message: format!("{}", err),
-                kind: MessageKind::Error,
-            };
-        }
+        self.show_hunk_context_menu(hunk_idx);
         true
     }
 
@@ -7688,15 +7736,12 @@ impl Gui {
     /// or hovered revert hunk). Cancel is focused first so an accidental
     /// Enter doesn't revert anything.
     fn show_hunk_context_menu(&mut self, hunk_idx: usize) {
-        // The Files diff pane shows the unstaged diff when the file has
-        // unstaged changes, otherwise the staged diff. Only offer the action
-        // that matches the visible hunks so the hunk index can't be applied
-        // to the wrong side of the index.
-        let (has_unstaged, has_staged) = self
-            .selected_file_index()
-            .and_then(|i| self.model.lock().unwrap().files.get(i).cloned())
-            .map(|f| (f.has_unstaged_changes, f.has_staged_changes))
-            .unwrap_or((false, false));
+        // Directory hovers have no single file to act on — Cancel only.
+        let has_file = self.selected_file_index().is_some();
+        // The Files pane shows unstaged + staged hunks in one buffer. Offer
+        // the action matching the hunk the menu was opened on so the index
+        // can't be applied to the wrong side of the index.
+        let hunk_is_staged = has_file && self.diff_view.is_staged_hunk(hunk_idx);
         let mut items = vec![popup::MenuItem {
             label: "Cancel".to_string(),
             description: String::new(),
@@ -7707,11 +7752,11 @@ impl Gui {
             // menu Esc handler.
             action: Some(Box::new(|_gui| Ok(()))),
         }];
-        if has_unstaged {
+        if has_file && !hunk_is_staged {
             items.push(popup::MenuItem {
                 label: "Stage hunk".to_string(),
                 description: String::new(),
-                key: None,
+                key: Some("s".to_string()),
                 action: Some(Box::new(move |gui| {
                     if let Err(err) = gui.stage_selected_file_hunk(hunk_idx) {
                         gui.popup = PopupState::Message {
@@ -7726,7 +7771,7 @@ impl Gui {
             items.push(popup::MenuItem {
                 label: "Revert hunk".to_string(),
                 description: String::new(),
-                key: None,
+                key: Some("r".to_string()),
                 action: Some(Box::new(move |gui| {
                     if let Err(err) = gui.revert_selected_file_hunk(hunk_idx) {
                         gui.popup = PopupState::Message {
@@ -7739,11 +7784,11 @@ impl Gui {
                 })),
             });
         }
-        if has_staged && !has_unstaged {
+        if hunk_is_staged {
             items.push(popup::MenuItem {
                 label: "Unstage hunk".to_string(),
                 description: String::new(),
-                key: None,
+                key: Some("u".to_string()),
                 action: Some(Box::new(move |gui| {
                     if let Err(err) = gui.unstage_selected_file_hunk(hunk_idx) {
                         gui.popup = PopupState::Message {
@@ -7765,6 +7810,39 @@ impl Gui {
         };
     }
 
+    /// Match the viewed HEAD block against the blocks of a freshly fetched
+    /// per-side diff, returning their slice ranges for patch building.
+    /// Matching runs on the side both diffs share (worktree for unstaged,
+    /// HEAD for staged) so staged edits elsewhere in the file can't shift
+    /// the mapping. Sorted deepest-first so sequential applies don't shift
+    /// the line numbers of pending ones.
+    fn matching_side_blocks(
+        &self,
+        hunk_idx: usize,
+        side_diff: &str,
+        new_side: bool,
+    ) -> Vec<(Option<(usize, usize)>, Option<(usize, usize)>)> {
+        let view_spans =
+            DiffViewState::block_spans(&self.diff_view.lines, &self.diff_view.hunk_line_offsets);
+        let Some(view) = view_spans.get(hunk_idx) else {
+            return Vec::new();
+        };
+        let mut matched: Vec<(usize, Option<(usize, usize)>, Option<(usize, usize)>)> =
+            DiffViewState::block_spans_for_diff(side_diff, 4)
+                .into_iter()
+                .filter(|s| view.overlaps(s, new_side))
+                .map(|s| {
+                    let anchor = s.old.map(|(lo, _)| lo).unwrap_or(s.old_point);
+                    (anchor, s.old, s.new)
+                })
+                .collect();
+        matched.sort_by(|a, b| b.0.cmp(&a.0));
+        matched
+            .into_iter()
+            .map(|(_, old, new)| (old, new))
+            .collect()
+    }
+
     fn stage_selected_file_hunk(&mut self, hunk_idx: usize) -> Result<()> {
         let Some(file_idx) = self.selected_file_index() else {
             return Ok(());
@@ -7774,13 +7852,6 @@ impl Gui {
             return Ok(());
         };
         drop(model);
-
-        let Some((want_old, want_new)) = self.diff_view.visual_block_line_ranges(hunk_idx) else {
-            return Ok(());
-        };
-        if want_old.is_none() && want_new.is_none() {
-            return Ok(());
-        }
 
         let path_refs: Vec<String> = file.diff_paths().into_iter().map(str::to_string).collect();
         let refs: Vec<&str> = path_refs.iter().map(String::as_str).collect();
@@ -7796,8 +7867,25 @@ impl Gui {
             return Ok(());
         }
 
-        self.git
-            .stage_visual_block(file.current_path(), &diff, want_old, want_new)?;
+        // The view may be a HEAD buffer, so map the hunk onto the unstaged
+        // diff's blocks via the shared worktree side.
+        let targets = self.matching_side_blocks(hunk_idx, &diff, true);
+        if targets.is_empty() {
+            self.popup = PopupState::Message {
+                title: "Stage hunk".to_string(),
+                message: "That hunk moved — the diff was refreshed.".to_string(),
+                kind: MessageKind::Info,
+            };
+            self.needs_diff_refresh = true;
+            return Ok(());
+        }
+        for (want_old, want_new) in targets {
+            if want_old.is_none() && want_new.is_none() {
+                continue;
+            }
+            self.git
+                .stage_visual_block(file.current_path(), &diff, want_old, want_new)?;
+        }
         self.needs_files_refresh = true;
         self.needs_diff_refresh = true;
         Ok(())
@@ -7813,13 +7901,6 @@ impl Gui {
         };
         drop(model);
 
-        let Some((want_old, want_new)) = self.diff_view.visual_block_line_ranges(hunk_idx) else {
-            return Ok(());
-        };
-        if want_old.is_none() && want_new.is_none() {
-            return Ok(());
-        }
-
         let path_refs: Vec<String> = file.diff_paths().into_iter().map(str::to_string).collect();
         let refs: Vec<&str> = path_refs.iter().map(String::as_str).collect();
         let diff = self.git.diff_file_staged_paths(&refs)?;
@@ -7827,8 +7908,25 @@ impl Gui {
             return Ok(());
         }
 
-        self.git
-            .unstage_visual_block(file.current_path(), &diff, want_old, want_new)?;
+        // The view may be a HEAD buffer, so map the hunk onto the staged
+        // diff's blocks via the shared HEAD side.
+        let targets = self.matching_side_blocks(hunk_idx, &diff, false);
+        if targets.is_empty() {
+            self.popup = PopupState::Message {
+                title: "Unstage hunk".to_string(),
+                message: "That hunk moved — the diff was refreshed.".to_string(),
+                kind: MessageKind::Info,
+            };
+            self.needs_diff_refresh = true;
+            return Ok(());
+        }
+        for (want_old, want_new) in targets {
+            if want_old.is_none() && want_new.is_none() {
+                continue;
+            }
+            self.git
+                .unstage_visual_block(file.current_path(), &diff, want_old, want_new)?;
+        }
         self.needs_files_refresh = true;
         self.needs_diff_refresh = true;
         Ok(())
@@ -7856,15 +7954,21 @@ impl Gui {
         let file_name = file.name.clone();
         drop(model);
 
-        let Some((want_old, want_new)) = self.diff_view.visual_block_line_ranges(hunk_idx) else {
-            return Ok(());
-        };
-        if want_old.is_none() && want_new.is_none() {
+        let diff = self.git.diff_file(&file_name)?;
+        if diff.is_empty() {
             return Ok(());
         }
 
-        let diff = self.git.diff_file(&file_name)?;
-        if diff.is_empty() {
+        // The view may be a HEAD buffer, so map the hunk onto the unstaged
+        // diff's blocks via the shared worktree side.
+        let targets = self.matching_side_blocks(hunk_idx, &diff, true);
+        if targets.is_empty() {
+            self.popup = PopupState::Message {
+                title: "Revert block".to_string(),
+                message: "That hunk moved — the diff was refreshed.".to_string(),
+                kind: MessageKind::Info,
+            };
+            self.needs_diff_refresh = true;
             return Ok(());
         }
 
@@ -7874,8 +7978,13 @@ impl Gui {
         let abs_path = self.git.repo_path().join(&file_name);
         let pre_bytes = std::fs::read(&abs_path).ok();
 
-        self.git
-            .revert_visual_block_in_worktree(&file_name, &diff, want_old, want_new)?;
+        for (want_old, want_new) in targets {
+            if want_old.is_none() && want_new.is_none() {
+                continue;
+            }
+            self.git
+                .revert_visual_block_in_worktree(&file_name, &diff, want_old, want_new)?;
+        }
 
         if let Some(bytes) = pre_bytes {
             let stack = &mut self.diff_view.revert_undo_stack;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -2960,9 +2960,9 @@ impl Gui {
                     self.queue_diff_job(generation, diff_key, move || {
                         let path_refs: Vec<&str> = diff_paths.iter().map(String::as_str).collect();
                         // Both sides present: one buffer with unstaged
-                        // hunks on top, a `Staged changes` separator, then
-                        // staged hunks. Falls back to the single-side view
-                        // when a side is unavailable.
+                        // hunks under `name (Unstaged)`, then staged hunks
+                        // under `name (Staged)`. Falls back to the
+                        // single-side view when a side is unavailable.
                         if has_unstaged && has_staged {
                             let exists = git.repo_path().join(&current_path).exists();
                             match (
@@ -3069,10 +3069,10 @@ impl Gui {
                                     Some(p) => vec![p],
                                     None => Vec::new(),
                                 };
-                                // Directory hover: unstaged multi-file diff on
-                                // top, a `Staged changes` separator, then the
-                                // staged multi-file diff — same stacking as
-                                // the single-file view. Untracked children
+                                // Directory hover: per-file grouping with
+                                // `name (Unstaged)` immediately followed by
+                                // `name (Staged)` — same grouping as the
+                                // single-file view. Untracked children
                                 // only exist unstaged. Hunk actions stay
                                 // Cancel-only here (no single file to act on).
                                 let mut unstaged_combined =

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -7688,18 +7688,42 @@ impl Gui {
     /// or hovered revert hunk). Cancel is focused first so an accidental
     /// Enter doesn't revert anything.
     fn show_hunk_context_menu(&mut self, hunk_idx: usize) {
-        let items = vec![
-            popup::MenuItem {
-                label: "Cancel".to_string(),
+        // The Files diff pane shows the unstaged diff when the file has
+        // unstaged changes, otherwise the staged diff. Only offer the action
+        // that matches the visible hunks so the hunk index can't be applied
+        // to the wrong side of the index.
+        let (has_unstaged, has_staged) = self
+            .selected_file_index()
+            .and_then(|i| self.model.lock().unwrap().files.get(i).cloned())
+            .map(|f| (f.has_unstaged_changes, f.has_staged_changes))
+            .unwrap_or((false, false));
+        let mut items = vec![popup::MenuItem {
+            label: "Cancel".to_string(),
+            description: String::new(),
+            key: None,
+            // No-op: execute_menu_action already drops the menu popup
+            // before invoking the action, so returning Ok leaves the
+            // menu closed. Esc also closes the menu via the universal
+            // menu Esc handler.
+            action: Some(Box::new(|_gui| Ok(()))),
+        }];
+        if has_unstaged {
+            items.push(popup::MenuItem {
+                label: "Stage hunk".to_string(),
                 description: String::new(),
                 key: None,
-                // No-op: execute_menu_action already drops the menu popup
-                // before invoking the action, so returning Ok leaves the
-                // menu closed. Esc also closes the menu via the universal
-                // menu Esc handler.
-                action: Some(Box::new(|_gui| Ok(()))),
-            },
-            popup::MenuItem {
+                action: Some(Box::new(move |gui| {
+                    if let Err(err) = gui.stage_selected_file_hunk(hunk_idx) {
+                        gui.popup = PopupState::Message {
+                            title: "Stage hunk failed".to_string(),
+                            message: format!("{}", err),
+                            kind: MessageKind::Error,
+                        };
+                    }
+                    Ok(())
+                })),
+            });
+            items.push(popup::MenuItem {
                 label: "Revert hunk".to_string(),
                 description: String::new(),
                 key: None,
@@ -7713,8 +7737,25 @@ impl Gui {
                     }
                     Ok(())
                 })),
-            },
-        ];
+            });
+        }
+        if has_staged && !has_unstaged {
+            items.push(popup::MenuItem {
+                label: "Unstage hunk".to_string(),
+                description: String::new(),
+                key: None,
+                action: Some(Box::new(move |gui| {
+                    if let Err(err) = gui.unstage_selected_file_hunk(hunk_idx) {
+                        gui.popup = PopupState::Message {
+                            title: "Unstage hunk failed".to_string(),
+                            message: format!("{}", err),
+                            kind: MessageKind::Error,
+                        };
+                    }
+                    Ok(())
+                })),
+            });
+        }
 
         self.popup = PopupState::Menu {
             title: "Hunk".to_string(),
@@ -7722,6 +7763,75 @@ impl Gui {
             selected: 0,
             loading_index: None,
         };
+    }
+
+    fn stage_selected_file_hunk(&mut self, hunk_idx: usize) -> Result<()> {
+        let Some(file_idx) = self.selected_file_index() else {
+            return Ok(());
+        };
+        let model = self.model.lock().unwrap();
+        let Some(file) = model.files.get(file_idx).cloned() else {
+            return Ok(());
+        };
+        drop(model);
+
+        let Some((want_old, want_new)) = self.diff_view.visual_block_line_ranges(hunk_idx) else {
+            return Ok(());
+        };
+        if want_old.is_none() && want_new.is_none() {
+            return Ok(());
+        }
+
+        let path_refs: Vec<String> = file.diff_paths().into_iter().map(str::to_string).collect();
+        let refs: Vec<&str> = path_refs.iter().map(String::as_str).collect();
+        let diff = self.git.diff_file_paths(&refs)?;
+        if diff.is_empty() {
+            // Untracked / synthesized diffs have no unified diff to slice —
+            // fall back to staging the whole file.
+            if !file.tracked {
+                self.git.stage_file(file.current_path())?;
+                self.needs_files_refresh = true;
+                self.needs_diff_refresh = true;
+            }
+            return Ok(());
+        }
+
+        self.git
+            .stage_visual_block(file.current_path(), &diff, want_old, want_new)?;
+        self.needs_files_refresh = true;
+        self.needs_diff_refresh = true;
+        Ok(())
+    }
+
+    fn unstage_selected_file_hunk(&mut self, hunk_idx: usize) -> Result<()> {
+        let Some(file_idx) = self.selected_file_index() else {
+            return Ok(());
+        };
+        let model = self.model.lock().unwrap();
+        let Some(file) = model.files.get(file_idx).cloned() else {
+            return Ok(());
+        };
+        drop(model);
+
+        let Some((want_old, want_new)) = self.diff_view.visual_block_line_ranges(hunk_idx) else {
+            return Ok(());
+        };
+        if want_old.is_none() && want_new.is_none() {
+            return Ok(());
+        }
+
+        let path_refs: Vec<String> = file.diff_paths().into_iter().map(str::to_string).collect();
+        let refs: Vec<&str> = path_refs.iter().map(String::as_str).collect();
+        let diff = self.git.diff_file_staged_paths(&refs)?;
+        if diff.is_empty() {
+            return Ok(());
+        }
+
+        self.git
+            .unstage_visual_block(file.current_path(), &diff, want_old, want_new)?;
+        self.needs_files_refresh = true;
+        self.needs_diff_refresh = true;
+        Ok(())
     }
 
     fn revert_selected_file_hunk(&mut self, hunk_idx: usize) -> Result<()> {

--- a/src/pager/side_by_side.rs
+++ b/src/pager/side_by_side.rs
@@ -353,6 +353,22 @@ pub struct DiffViewState {
     pub revert_undo_high_water: usize,
 }
 
+/// Suffix a file header with its index side so unstaged/staged hunks stay
+/// distinguishable when both are shown in one buffer:
+/// `README.md (Unstaged)` / `README.md (Staged)`.
+fn staged_file_header(name: &str, staged: bool) -> String {
+    format!("{} ({})", name, if staged { "Staged" } else { "Unstaged" })
+}
+
+/// Strip a ` (Staged)` / ` (Unstaged)` suffix back to the plain path so
+/// header text can still resolve to a file on disk.
+fn strip_staged_suffix(header: &str) -> &str {
+    header
+        .strip_suffix(" (Staged)")
+        .or_else(|| header.strip_suffix(" (Unstaged)"))
+        .unwrap_or(header)
+}
+
 impl Default for DiffViewState {
     fn default() -> Self {
         Self {
@@ -450,7 +466,7 @@ impl DiffViewState {
     pub fn file_at_line(&self, line_idx: usize) -> &str {
         for i in (0..=line_idx).rev() {
             if let Some(ref header) = self.lines.get(i).and_then(|l| l.file_header.as_ref()) {
-                return header;
+                return strip_staged_suffix(header);
             }
         }
         &self.filename
@@ -590,11 +606,12 @@ impl DiffViewState {
     }
 
     /// Parse a single file's unstaged + staged diffs into one scrollable
-    /// buffer: unstaged hunks first, then a `Staged changes` separator and
-    /// the staged hunks. `hunk_staged` records which section each hunk came
-    /// from so the hunk menu can offer Stage vs Unstage per hunk. Either
-    /// side may be empty (all-staged / all-unstaged file); the separator
-    /// only appears when both sides have content.
+    /// buffer: unstaged hunks under a `name (Unstaged)` header, then the
+    /// staged hunks under `name (Staged)`. `hunk_staged` records which
+    /// section each hunk came from so the hunk menu can offer Stage vs
+    /// Unstage per hunk. Either side may be empty (all-staged /
+    /// all-unstaged file); the per-side headers only appear when both
+    /// sides have content.
     pub fn parse_combined_file_diff(
         filename: &str,
         unstaged_diff: &str,
@@ -615,51 +632,124 @@ impl DiffViewState {
         let (unstaged_old, unstaged_new) = parse_unified_diff(unstaged_diff);
         let (staged_old, staged_new) = parse_unified_diff(staged_diff);
 
-        let mut lines = diff_lines_from_unified_or_rename_only(unstaged_diff, tab_width);
-        let mut hunk_starts = super::diff_algo::find_hunk_starts(&lines);
-        let mut hunk_staged = vec![false; hunk_starts.len()];
-        let hunks_u = parse_hunk_headers(unstaged_diff);
-        let mut hunk_line_offsets = build_hunk_line_offsets(&hunks_u, &lines, 0);
-        let mut sections = vec![FileSection {
-            old_highlighter: FileHighlighter::new(&unstaged_old, &actual_name),
-            new_highlighter: FileHighlighter::new(&unstaged_new, &actual_name),
-        }];
+        let unstaged_lines = diff_lines_from_unified_or_rename_only(unstaged_diff, tab_width);
+        let staged_lines = if staged_diff.trim().is_empty() {
+            Vec::new()
+        } else {
+            diff_lines_from_unified_or_rename_only(staged_diff, tab_width)
+        };
 
-        if !staged_diff.trim().is_empty() {
-            let mut staged_lines = diff_lines_from_unified_or_rename_only(staged_diff, tab_width);
-            if !staged_lines.is_empty() {
-                if !lines.is_empty() {
-                    lines.push(DiffLine {
-                        old_line: None,
-                        new_line: None,
-                        change_type: ChangeType::Equal,
-                        old_segments: None,
-                        new_segments: None,
-                        file_header: Some("Staged changes".to_string()),
-                        section_index: 1,
-                    });
-                }
-                let section_start = lines.len();
+        // Single-side fast path: keep the previous headerless buffer.
+        if unstaged_lines.is_empty() || staged_lines.is_empty() {
+            let mut lines = unstaged_lines;
+            let mut hunk_starts = super::diff_algo::find_hunk_starts(&lines);
+            let mut hunk_staged = vec![false; hunk_starts.len()];
+            let hunks_u = parse_hunk_headers(unstaged_diff);
+            let mut hunk_line_offsets = build_hunk_line_offsets(&hunks_u, &lines, 0);
+            let mut sections = vec![FileSection {
+                old_highlighter: FileHighlighter::new(&unstaged_old, &actual_name),
+                new_highlighter: FileHighlighter::new(&unstaged_new, &actual_name),
+            }];
+            if lines.is_empty() {
+                let mut staged_lines = staged_lines;
                 for line in &mut staged_lines {
                     line.section_index = 1;
                 }
                 let staged_starts = super::diff_algo::find_hunk_starts(&staged_lines);
                 for s in staged_starts {
-                    hunk_starts.push(section_start + s);
+                    hunk_starts.push(s);
                     hunk_staged.push(true);
                 }
-                lines.append(&mut staged_lines);
+                lines = staged_lines;
                 let hunks_s = parse_hunk_headers(staged_diff);
-                let staged_offsets = build_hunk_line_offsets(&hunks_s, &lines[section_start..], 0);
-                for (idx, old_off, new_off) in staged_offsets {
-                    hunk_line_offsets.push((section_start + idx, old_off, new_off));
-                }
+                hunk_line_offsets = build_hunk_line_offsets(&hunks_s, &lines, 0);
                 sections.push(FileSection {
                     old_highlighter: FileHighlighter::new(&staged_old, &actual_name),
                     new_highlighter: FileHighlighter::new(&staged_new, &actual_name),
                 });
+                sections.remove(0);
+            }
+            // Left leans HEAD-ish (staged old), right leans worktree
+            // (unstaged new), falling back to whichever side exists.
+            let old_content = if staged_old.is_empty() {
+                unstaged_old
+            } else {
+                staged_old
+            };
+            let new_content = if unstaged_new.is_empty() {
+                staged_new
+            } else {
+                unstaged_new
+            };
+            return ParsedDiff {
+                filename: actual_name,
+                old_content,
+                new_content,
+                lines,
+                hunk_starts,
+                hunk_staged,
+                hunk_line_offsets,
+                sections,
+                file_exists_on_disk,
+            };
+        }
+
+        fn header_line(name: &str, staged: bool, section_index: usize) -> DiffLine {
+            DiffLine {
+                old_line: None,
+                new_line: None,
+                change_type: ChangeType::Equal,
+                old_segments: None,
+                new_segments: None,
+                file_header: Some(staged_file_header(name, staged)),
+                section_index,
             }
         }
+
+        let mut lines = Vec::with_capacity(unstaged_lines.len() + staged_lines.len() + 2);
+        lines.push(header_line(&actual_name, false, 0));
+        let unstaged_start = lines.len();
+        lines.extend(unstaged_lines);
+        lines.push(header_line(&actual_name, true, 1));
+        let staged_start = lines.len();
+        let mut staged_lines = staged_lines;
+        for line in &mut staged_lines {
+            line.section_index = 1;
+        }
+        lines.extend(staged_lines);
+
+        let hunks_u = parse_hunk_headers(unstaged_diff);
+        let hunks_s = parse_hunk_headers(staged_diff);
+        let mut hunk_starts = Vec::new();
+        let mut hunk_staged = Vec::new();
+        let mut hunk_line_offsets = Vec::new();
+        for (idx, old_off, new_off) in
+            build_hunk_line_offsets(&hunks_u, &lines[unstaged_start..staged_start - 1], 0)
+        {
+            hunk_line_offsets.push((unstaged_start + idx, old_off, new_off));
+        }
+        for s in super::diff_algo::find_hunk_starts(&lines[unstaged_start..staged_start - 1]) {
+            hunk_starts.push(unstaged_start + s);
+            hunk_staged.push(false);
+        }
+        for (idx, old_off, new_off) in build_hunk_line_offsets(&hunks_s, &lines[staged_start..], 0)
+        {
+            hunk_line_offsets.push((staged_start + idx, old_off, new_off));
+        }
+        for s in super::diff_algo::find_hunk_starts(&lines[staged_start..]) {
+            hunk_starts.push(staged_start + s);
+            hunk_staged.push(true);
+        }
+        let sections = vec![
+            FileSection {
+                old_highlighter: FileHighlighter::new(&unstaged_old, &actual_name),
+                new_highlighter: FileHighlighter::new(&unstaged_new, &actual_name),
+            },
+            FileSection {
+                old_highlighter: FileHighlighter::new(&staged_old, &actual_name),
+                new_highlighter: FileHighlighter::new(&staged_new, &actual_name),
+            },
+        ];
 
         // Left leans HEAD-ish (staged old), right leans worktree
         // (unstaged new), falling back to whichever side exists.
@@ -687,46 +777,221 @@ impl DiffViewState {
         }
     }
 
-    /// Stack two already-parsed diffs (e.g. multi-file directory hovers)
-    /// with a `Staged changes` separator between them. Hunk starts and
-    /// line-offset indices of the second half are rebased past the first
-    /// half + separator, and its section indices are bumped past the
-    /// first half's sections. The separator is omitted when either half
-    /// is empty. Callers set each half's `hunk_staged` before combining.
-    pub fn combine_parsed_with_separator(
-        mut first: ParsedDiff,
-        mut second: ParsedDiff,
-    ) -> ParsedDiff {
+    /// Group two already-parsed diffs (e.g. multi-file directory hovers) by
+    /// file: each file's unstaged hunks appear under `name (Unstaged)`
+    /// immediately followed by its staged hunks under `name (Staged)`, so a
+    /// staged file never reads as a second copy of the buffer. Files only
+    /// on one side keep a single suffixed header. Returns either half
+    /// unchanged (plain headers, no suffix) when the other half is empty.
+    /// Callers set each half's `hunk_staged` before combining.
+    pub fn combine_parsed_with_separator(first: ParsedDiff, second: ParsedDiff) -> ParsedDiff {
         if second.lines.is_empty() {
             return first;
         }
         if first.lines.is_empty() {
             return second;
         }
-        let section_base = first.sections.len();
-        let base = first.lines.len() + 1;
-        first.lines.push(DiffLine {
-            old_line: None,
-            new_line: None,
-            change_type: ChangeType::Equal,
-            old_segments: None,
-            new_segments: None,
-            file_header: Some("Staged changes".to_string()),
-            section_index: section_base,
-        });
-        for line in &mut second.lines {
-            line.section_index += section_base;
+
+        struct Chunk {
+            name: String,
+            lines: Vec<DiffLine>,
+            section_idx: usize,
+            hunks: Vec<(usize, bool)>,
+            offsets: Vec<(usize, usize, usize)>,
         }
-        first.lines.append(&mut second.lines);
-        for s in second.hunk_starts {
-            first.hunk_starts.push(base + s);
+
+        // Split a parsed half into per-file chunks, keyed by plain filename.
+        // Hunk starts/offsets are rebased to content-relative indices.
+        // Repeat headers for one file stay as separate chunks so original
+        // indices always map exactly; emission merges them per filename.
+        fn split(parsed: &ParsedDiff) -> Vec<Chunk> {
+            let mut chunks: Vec<Chunk> = Vec::new();
+            // (chunk_idx, content_start, content_end) for hunk attribution.
+            let mut spans: Vec<(usize, usize, usize)> = Vec::new();
+            let mut open_name: Option<String> = None;
+            let mut open_section: usize = 0;
+            let mut open_start: usize = 0;
+            let mut open_lines: Vec<DiffLine> = Vec::new();
+
+            let flush = |chunks: &mut Vec<Chunk>,
+                         spans: &mut Vec<(usize, usize, usize)>,
+                         name: &mut Option<String>,
+                         lines: &mut Vec<DiffLine>,
+                         section: usize,
+                         start: usize| {
+                if let Some(n) = name.take() {
+                    let idx = chunks.len();
+                    spans.push((idx, start, start + lines.len()));
+                    chunks.push(Chunk {
+                        name: n,
+                        lines: std::mem::take(lines),
+                        section_idx: section,
+                        hunks: Vec::new(),
+                        offsets: Vec::new(),
+                    });
+                }
+            };
+
+            for (idx, line) in parsed.lines.iter().enumerate() {
+                if let Some(ref header) = line.file_header {
+                    flush(
+                        &mut chunks,
+                        &mut spans,
+                        &mut open_name,
+                        &mut open_lines,
+                        open_section,
+                        open_start,
+                    );
+                    open_name = Some(strip_staged_suffix(header).to_string());
+                    open_section = line.section_index;
+                    open_start = idx + 1;
+                } else {
+                    if open_name.is_none() {
+                        // Headerless (single-file) half: synthesize the name.
+                        open_name = Some(strip_staged_suffix(&parsed.filename).to_string());
+                        open_section = line.section_index;
+                        open_start = idx;
+                    }
+                    open_lines.push(line.clone());
+                }
+            }
+            flush(
+                &mut chunks,
+                &mut spans,
+                &mut open_name,
+                &mut open_lines,
+                open_section,
+                open_start,
+            );
+
+            // Attribute hunks/offsets to the chunk whose original span holds them.
+            for (hi, &s) in parsed.hunk_starts.iter().enumerate() {
+                let staged = parsed.hunk_staged.get(hi).copied().unwrap_or(false);
+                if let Some((ci, start, _)) =
+                    spans.iter().find(|(_, start, end)| s >= *start && s < *end)
+                {
+                    chunks[*ci].hunks.push((s - start, staged));
+                }
+            }
+            for (idx, old_off, new_off) in parsed.hunk_line_offsets.iter().copied() {
+                if let Some((ci, start, _)) = spans
+                    .iter()
+                    .find(|(_, start, end)| idx >= *start && idx < *end)
+                {
+                    chunks[*ci].offsets.push((idx - start, old_off, new_off));
+                }
+            }
+            chunks
         }
-        first.hunk_staged.append(&mut second.hunk_staged);
-        for (idx, old_off, new_off) in second.hunk_line_offsets {
-            first.hunk_line_offsets.push((base + idx, old_off, new_off));
+
+        let first_chunks = split(&first);
+        let second_chunks = split(&second);
+        if first_chunks.is_empty() && second_chunks.is_empty() {
+            return first;
         }
-        first.sections.append(&mut second.sections);
-        first
+
+        // Emission order: unstaged file order, then staged-only files.
+        let mut order: Vec<String> = Vec::new();
+        for c in &first_chunks {
+            if !order.contains(&c.name) {
+                order.push(c.name.clone());
+            }
+        }
+        for c in &second_chunks {
+            if !order.contains(&c.name) {
+                order.push(c.name.clone());
+            }
+        }
+
+        let mut first_sections: Vec<Option<FileSection>> =
+            first.sections.into_iter().map(Some).collect();
+        let mut second_sections: Vec<Option<FileSection>> =
+            second.sections.into_iter().map(Some).collect();
+        let take_section =
+            |sections: &mut Vec<Option<FileSection>>, idx: usize, fallback_name: &str| {
+                sections
+                    .get_mut(idx)
+                    .and_then(|s| s.take())
+                    .unwrap_or_else(|| FileSection {
+                        old_highlighter: FileHighlighter::new("", fallback_name),
+                        new_highlighter: FileHighlighter::new("", fallback_name),
+                    })
+            };
+
+        fn header_line(name: &str, staged: bool, section_index: usize) -> DiffLine {
+            DiffLine {
+                old_line: None,
+                new_line: None,
+                change_type: ChangeType::Equal,
+                old_segments: None,
+                new_segments: None,
+                file_header: Some(staged_file_header(name, staged)),
+                section_index,
+            }
+        }
+
+        let first_name = first.filename.clone();
+        let first_old = first.old_content.clone();
+        let first_new = first.new_content.clone();
+        let first_exists = first.file_exists_on_disk;
+        let mut lines: Vec<DiffLine> = Vec::new();
+        let mut sections: Vec<FileSection> = Vec::new();
+        let mut hunk_starts: Vec<usize> = Vec::new();
+        let mut hunk_staged: Vec<bool> = Vec::new();
+        let mut hunk_line_offsets: Vec<(usize, usize, usize)> = Vec::new();
+
+        // Emit one suffixed header + content block per chunk so repeat
+        // headers for a file each keep their own section/highlighter.
+        let mut emit =
+            |chunk: &Chunk, staged: bool, take: &mut dyn FnMut(usize, &str) -> FileSection| {
+                let section = take(chunk.section_idx, &chunk.name);
+                let section_index = sections.len();
+                lines.push(header_line(&chunk.name, staged, section_index));
+                let content_start = lines.len();
+                for mut line in chunk.lines.clone() {
+                    line.section_index = section_index;
+                    lines.push(line);
+                }
+                for (rel, s) in &chunk.hunks {
+                    hunk_starts.push(content_start + rel);
+                    hunk_staged.push(*s);
+                }
+                for (rel, old_off, new_off) in &chunk.offsets {
+                    hunk_line_offsets.push((content_start + rel, *old_off, *new_off));
+                }
+                sections.push(section);
+            };
+
+        for name in &order {
+            for chunk in first_chunks.iter().filter(|c| &c.name == name) {
+                let mut take =
+                    |idx: usize, fallback: &str| take_section(&mut first_sections, idx, fallback);
+                emit(chunk, false, &mut take);
+            }
+            for chunk in second_chunks.iter().filter(|c| &c.name == name) {
+                let mut take =
+                    |idx: usize, fallback: &str| take_section(&mut second_sections, idx, fallback);
+                emit(chunk, true, &mut take);
+            }
+        }
+
+        // Keep hunk indices ascending in emission order.
+        let mut hunk_order: Vec<usize> = (0..hunk_starts.len()).collect();
+        hunk_order.sort_by_key(|&i| hunk_starts[i]);
+        let hunk_starts = hunk_order.iter().map(|&i| hunk_starts[i]).collect();
+        let hunk_staged = hunk_order.iter().map(|&i| hunk_staged[i]).collect();
+
+        ParsedDiff {
+            filename: first_name,
+            old_content: first_old,
+            new_content: first_new,
+            lines,
+            hunk_starts,
+            hunk_staged,
+            hunk_line_offsets,
+            sections,
+            file_exists_on_disk: first_exists,
+        }
     }
 
     /// Parse raw diff output into a ParsedDiff on any thread (no &self needed).
@@ -2411,8 +2676,8 @@ fn unified_line_number_text(num: Option<usize>, chunk_idx: usize) -> String {
     }
 }
 
-/// Glyph + foreground for a hunk marker. Sections are split by a
-/// `Staged changes` separator, so every marker uses the same `󰧛` glyph:
+/// Glyph + foreground for a hunk marker. Sections carry `(Unstaged)` /
+/// `(Staged)` headers, so every marker uses the same `󰧛` glyph:
 /// blue when focused, dim otherwise. No hover color — hover only shows
 /// the tooltip, selection alone drives the highlight.
 fn hunk_marker_glyph_and_fg(
@@ -3435,13 +3700,13 @@ mod tests {
         let parsed = DiffViewState::parse_combined_file_diff("f.txt", unstaged, staged, 4, true);
         assert_eq!(parsed.hunk_starts.len(), 2);
         assert_eq!(parsed.hunk_staged, vec![false, true]);
-        // A `Staged changes` separator sits between the two sections.
-        assert!(
-            parsed
-                .lines
-                .iter()
-                .any(|l| l.file_header.as_deref() == Some("Staged changes"))
-        );
+        // Per-side headers label each section; no global separator.
+        let headers: Vec<&str> = parsed
+            .lines
+            .iter()
+            .filter_map(|l| l.file_header.as_deref())
+            .collect();
+        assert_eq!(headers, vec!["f.txt (Unstaged)", "f.txt (Staged)"]);
         // Each section keeps its own side's file numbers, which is what
         // stage/unstage sub-patch slicing consumes directly.
         let mut state = DiffViewState::new();
@@ -3492,14 +3757,46 @@ mod tests {
         let combined = DiffViewState::combine_parsed_with_separator(a, b);
         assert_eq!(combined.hunk_starts.len(), 2);
         assert_eq!(combined.hunk_staged, vec![false, true]);
-        assert!(
-            combined
-                .lines
-                .iter()
-                .any(|l| l.file_header.as_deref() == Some("Staged changes"))
-        );
-        // The staged hunk moved past the first half + separator.
+        // Distinct files keep their own suffixed headers, unstaged order first.
+        let headers: Vec<&str> = combined
+            .lines
+            .iter()
+            .filter_map(|l| l.file_header.as_deref())
+            .collect();
+        assert_eq!(headers, vec!["a.txt (Unstaged)", "c.txt (Staged)"]);
+        // The staged hunk moved past the first half + header.
         assert!(combined.hunk_starts[1] > combined.hunk_starts[0]);
+    }
+
+    #[test]
+    fn combine_parsed_groups_same_file_staged_below_unstaged() {
+        let a = DiffViewState::parse_diff_output(
+            "dir",
+            "diff --git a/a.txt b/a.txt\n--- a/a.txt\n+++ b/a.txt\n@@ -1,2 +1,2 @@\n a\n-b\n+B\n",
+            4,
+            true,
+        );
+        let b = DiffViewState::parse_diff_output(
+            "dir",
+            "diff --git a/a.txt b/a.txt\n--- a/a.txt\n+++ b/a.txt\n@@ -5,2 +5,2 @@\n x\n-y\n+Y\n",
+            4,
+            true,
+        );
+        let mut b = b;
+        b.hunk_staged = vec![true; b.hunk_starts.len()];
+        let combined = DiffViewState::combine_parsed_with_separator(a, b);
+        assert_eq!(combined.hunk_staged, vec![false, true]);
+        let headers: Vec<&str> = combined
+            .lines
+            .iter()
+            .filter_map(|l| l.file_header.as_deref())
+            .collect();
+        assert_eq!(headers, vec!["a.txt (Unstaged)", "a.txt (Staged)"]);
+        // Plain filenames still resolve for editor navigation.
+        let mut state = DiffViewState::new();
+        state.apply_parsed(combined);
+        assert_eq!(state.file_at_line(1), "a.txt");
+        assert_eq!(state.file_at_line(state.hunk_starts[1]), "a.txt");
     }
 
     #[test]

--- a/src/pager/side_by_side.rs
+++ b/src/pager/side_by_side.rs
@@ -24,6 +24,9 @@ pub struct ParsedDiff {
     pub new_content: String,
     pub lines: Vec<DiffLine>,
     pub hunk_starts: Vec<usize>,
+    /// Parallel to `hunk_starts`: true when the hunk comes from the staged
+    /// (`--cached`) diff, false for unstaged. Empty = unknown/unstaged.
+    pub hunk_staged: Vec<bool>,
     pub hunk_line_offsets: Vec<(usize, usize, usize)>,
     pub sections: Vec<FileSection>,
     pub file_exists_on_disk: bool,
@@ -298,6 +301,9 @@ pub struct DiffViewState {
     pub horizontal_scroll: usize,
     pub lines: Vec<DiffLine>,
     pub hunk_starts: Vec<usize>,
+    /// Parallel to `hunk_starts`: true when the hunk is staged. Empty for
+    /// non-Files diffs (commits, stash, …), where everything is unstaged.
+    pub hunk_staged: Vec<bool>,
     pub filename: String,
     pub old_content: String,
     pub new_content: String,
@@ -354,6 +360,7 @@ impl Default for DiffViewState {
             horizontal_scroll: 0,
             lines: Vec::new(),
             hunk_starts: Vec::new(),
+            hunk_staged: Vec::new(),
             filename: String::new(),
             old_content: String::new(),
             new_content: String::new(),
@@ -575,10 +582,142 @@ impl DiffViewState {
             new_content: new.to_string(),
             lines,
             hunk_starts,
+            hunk_staged: Vec::new(),
             hunk_line_offsets: Vec::new(),
             sections,
             file_exists_on_disk,
         }
+    }
+
+    /// Parse a `git diff HEAD` buffer for a file that has both staged and
+    /// unstaged changes, classifying each hunk via `unstaged_diff`.
+    ///
+    /// This is a true single buffer: one coherent set of line numbers (no
+    /// separator, no duplicated context). Both diffs share worktree
+    /// (new-side) numbering, so a HEAD hunk that overlaps no unstaged hunk
+    /// must be fully staged; anything touching unstaged work counts as
+    /// unstaged — including regions where staged and unstaged edits overlap.
+    pub fn parse_head_with_staged(
+        filename: &str,
+        head_diff: &str,
+        unstaged_diff: &str,
+        tab_width: usize,
+        file_exists_on_disk: bool,
+    ) -> ParsedDiff {
+        let mut parsed =
+            Self::parse_diff_output(filename, head_diff, tab_width, file_exists_on_disk);
+        parsed.hunk_staged = head_block_staged_flags(head_diff, unstaged_diff, tab_width);
+        // Defensive: block classification and the parsed view count blocks
+        // with the same walk, but never let the flags drift out of step.
+        if parsed.hunk_staged.len() != parsed.hunk_starts.len() {
+            parsed.hunk_staged = vec![false; parsed.hunk_starts.len()];
+        }
+        parsed
+    }
+
+    /// File-relative (old, new) line spans for every visual change block of
+    /// a raw unified diff, without tree-sitter highlighting. Used to map a
+    /// hunk the user acts on in the HEAD buffer onto the matching block(s)
+    /// of the staged/unstaged diff that patch slicing consumes.
+    pub fn block_spans_for_diff(diff_text: &str, tab_width: usize) -> Vec<BlockSpan> {
+        let lines = diff_lines_from_unified_or_rename_only(diff_text, tab_width);
+        let hunks = parse_hunk_headers(diff_text);
+        let file_header_count = lines.iter().take_while(|l| l.file_header.is_some()).count();
+        let offsets = build_hunk_line_offsets(&hunks, &lines, file_header_count);
+        Self::block_spans(&lines, &offsets)
+    }
+
+    /// File-relative spans for visual change blocks from already-parsed
+    /// lines. `old`/`new` are `None` for pure insertions/deletions; the
+    /// `*_point` gap positions still allow matching those blocks across
+    /// diffs that share a side (worktree for unstaged, HEAD for staged).
+    pub fn block_spans(
+        lines: &[DiffLine],
+        hunk_line_offsets: &[(usize, usize, usize)],
+    ) -> Vec<BlockSpan> {
+        let offsets_at = |idx: usize| {
+            let mut offsets = (0usize, 0usize);
+            for &(start_idx, old_off, new_off) in hunk_line_offsets {
+                if start_idx <= idx {
+                    offsets = (old_off, new_off);
+                } else {
+                    break;
+                }
+            }
+            offsets
+        };
+        let file_num = |idx: usize, new_side: bool| -> Option<usize> {
+            let (old_off, new_off) = offsets_at(idx);
+            let line = lines.get(idx)?;
+            if new_side {
+                line.new_line.as_ref().map(|(n, _)| *n + new_off)
+            } else {
+                line.old_line.as_ref().map(|(n, _)| *n + old_off)
+            }
+        };
+
+        let mut spans = Vec::new();
+        let mut start = 0usize;
+        while start < lines.len() {
+            if lines[start].file_header.is_some()
+                || matches!(lines[start].change_type, ChangeType::Equal)
+            {
+                start += 1;
+                continue;
+            }
+            let mut end = start;
+            while end < lines.len()
+                && lines[end].file_header.is_none()
+                && !matches!(lines[end].change_type, ChangeType::Equal)
+            {
+                end += 1;
+            }
+            let mut old_range: Option<(usize, usize)> = None;
+            let mut new_range: Option<(usize, usize)> = None;
+            for idx in start..end {
+                let line = &lines[idx];
+                if matches!(line.change_type, ChangeType::Delete | ChangeType::Modified) {
+                    if let Some(n) = file_num(idx, false) {
+                        old_range = Some(match old_range {
+                            None => (n, n),
+                            Some((lo, hi)) => (lo.min(n), hi.max(n)),
+                        });
+                    }
+                }
+                if matches!(line.change_type, ChangeType::Insert | ChangeType::Modified) {
+                    if let Some(n) = file_num(idx, true) {
+                        new_range = Some(match new_range {
+                            None => (n, n),
+                            Some((lo, hi)) => (lo.min(n), hi.max(n)),
+                        });
+                    }
+                }
+            }
+            // Gap position for pure insertions/deletions: just after the
+            // previous surviving line (0 when the block starts the file).
+            // Both parses of the same edit compute the same point because
+            // they share that side's content.
+            let gap_point = |new_side: bool| -> usize {
+                for idx in (0..start).rev() {
+                    if let Some(n) = file_num(idx, new_side) {
+                        return n + 1;
+                    }
+                }
+                0
+            };
+            spans.push(BlockSpan {
+                old: old_range,
+                new: new_range,
+                old_point: old_range
+                    .map(|(lo, _)| lo)
+                    .unwrap_or_else(|| gap_point(false)),
+                new_point: new_range
+                    .map(|(lo, _)| lo)
+                    .unwrap_or_else(|| gap_point(true)),
+            });
+            start = end;
+        }
+        spans
     }
 
     /// Parse raw diff output into a ParsedDiff on any thread (no &self needed).
@@ -609,6 +748,7 @@ impl DiffViewState {
                 old_content: old,
                 new_content: new,
                 lines,
+                hunk_staged: vec![false; hunk_starts.len()],
                 hunk_starts,
                 hunk_line_offsets,
                 sections,
@@ -659,6 +799,7 @@ impl DiffViewState {
                 old_content: String::new(),
                 new_content: String::new(),
                 lines,
+                hunk_staged: vec![false; hunk_starts.len()],
                 hunk_starts,
                 hunk_line_offsets,
                 sections,
@@ -677,6 +818,7 @@ impl DiffViewState {
         self.new_content = parsed.new_content;
         self.lines = parsed.lines;
         self.hunk_starts = parsed.hunk_starts;
+        self.hunk_staged = parsed.hunk_staged;
         self.hunk_line_offsets = parsed.hunk_line_offsets;
         self.sections = parsed.sections;
         self.file_exists_on_disk = parsed.file_exists_on_disk;
@@ -712,6 +854,7 @@ impl DiffViewState {
         self.new_content = new.to_string();
         self.lines = super::diff_algo::compute_side_by_side(old, new, self.tab_width);
         self.hunk_starts = super::diff_algo::find_hunk_starts(&self.lines);
+        self.hunk_staged.clear();
         self.hunk_line_offsets = Vec::new(); // Full content — no offsets needed
         if same_file {
             // Clamp scroll in case the diff got shorter
@@ -762,6 +905,7 @@ impl DiffViewState {
             self.new_content = new.clone();
             self.lines = diff_lines_from_unified_or_rename_only(diff_output, self.tab_width);
             self.hunk_starts = super::diff_algo::find_hunk_starts(&self.lines);
+            self.hunk_staged.clear();
             let hunks = parse_hunk_headers(diff_output);
             self.hunk_line_offsets = build_hunk_line_offsets(&hunks, &self.lines, 0);
             self.sections = vec![FileSection {
@@ -839,6 +983,7 @@ impl DiffViewState {
 
             self.sections = build_file_sections_parallel(&section_meta);
             self.hunk_starts = super::diff_algo::find_hunk_starts(&self.lines);
+            self.hunk_staged.clear();
             self.selected_revert_hunk = if same_file {
                 self.selected_revert_hunk
                     .filter(|&i| i < self.hunk_starts.len())
@@ -1204,6 +1349,12 @@ impl DiffViewState {
     /// Get the zero-based hunk index for a hunk-start line.
     pub fn hunk_index_for_start_line(&self, line_idx: usize) -> Option<usize> {
         self.hunk_starts.binary_search(&line_idx).ok()
+    }
+
+    /// True when hunk `hunk_idx` comes from the staged diff. Missing entries
+    /// (other contexts, legacy state) count as unstaged.
+    pub fn is_staged_hunk(&self, hunk_idx: usize) -> bool {
+        self.hunk_staged.get(hunk_idx).copied().unwrap_or(false)
     }
 
     /// For the visual hunk at `block_idx`, return the (old, new) line-number
@@ -1753,21 +1904,10 @@ pub fn render_diff(
                     } else {
                         None
                     };
-                    let marker_is_hovered = show_marker
-                        && marker_hunk_idx.is_some()
-                        && marker_hunk_idx == state.hovered_revert_hunk;
                     let (divider_char, marker_style) = if show_marker {
-                        let is_selected = marker_hunk_idx == state.selected_revert_hunk;
-                        // Hover wins over selection so the hover state is always
-                        // visible — even on a hunk that's currently selected.
-                        let fg = if marker_is_hovered {
-                            theme.accent_secondary
-                        } else if is_selected {
-                            theme.accent
-                        } else {
-                            theme.separator
-                        };
-                        ("󰧛", Style::default().fg(fg).add_modifier(Modifier::BOLD))
+                        let hunk_idx = marker_hunk_idx.unwrap_or(usize::MAX);
+                        let (glyph, fg) = hunk_marker_glyph_and_fg(state, hunk_idx, theme);
+                        (glyph, Style::default().fg(fg).add_modifier(Modifier::BOLD))
                     } else {
                         ("│", divider_style)
                     };
@@ -1862,19 +2002,10 @@ pub fn render_diff(
                 } else {
                     None
                 };
-                let marker_is_hovered = show_marker
-                    && marker_hunk_idx.is_some()
-                    && marker_hunk_idx == state.hovered_revert_hunk;
                 let (divider_char, marker_style) = if show_marker {
-                    let is_selected = marker_hunk_idx == state.selected_revert_hunk;
-                    let fg = if marker_is_hovered {
-                        theme.accent_secondary
-                    } else if is_selected {
-                        theme.accent
-                    } else {
-                        theme.separator
-                    };
-                    ("󰧛", Style::default().fg(fg).add_modifier(Modifier::BOLD))
+                    let hunk_idx = marker_hunk_idx.unwrap_or(usize::MAX);
+                    let (glyph, fg) = hunk_marker_glyph_and_fg(state, hunk_idx, theme);
+                    (glyph, Style::default().fg(fg).add_modifier(Modifier::BOLD))
                 } else {
                     ("│", divider_style)
                 };
@@ -1933,6 +2064,9 @@ pub fn render_diff(
         if let Some(y) = hover_tooltip_y {
             let show_key = state.hovered_revert_hunk.is_some()
                 && state.hovered_revert_hunk == state.selected_revert_hunk;
+            let staged = state
+                .hovered_revert_hunk
+                .is_some_and(|i| state.is_staged_hunk(i));
             render_revert_tooltip(
                 buf,
                 div_x + divider_width,
@@ -1940,6 +2074,7 @@ pub fn render_diff(
                 right_content_width + gutter_width,
                 theme,
                 show_key,
+                staged,
             );
         }
     }
@@ -2219,20 +2354,12 @@ fn render_unified_row(
 
         if chunk_idx == 0 {
             if let Some(hunk_idx) = marker_hunk_idx {
-                let is_hovered = Some(hunk_idx) == state.hovered_revert_hunk;
-                let is_selected = Some(hunk_idx) == state.selected_revert_hunk;
-                let fg = if is_hovered {
-                    theme.accent_secondary
-                } else if is_selected {
-                    theme.accent
-                } else {
-                    theme.separator
-                };
+                let (glyph, fg) = hunk_marker_glyph_and_fg(state, hunk_idx, theme);
                 buf_write_str(
                     buf,
                     prefix_x,
                     y,
-                    "󰧛",
+                    glyph,
                     Style::default()
                         .fg(fg)
                         .bg(gutter_bg)
@@ -2275,6 +2402,30 @@ fn unified_line_number_text(num: Option<usize>, chunk_idx: usize) -> String {
     }
 }
 
+/// Glyph + foreground for a hunk marker: blue `󰧛` for the focused
+/// (unstaged) hunk, green `✓` for staged hunks. No hover color — hover only
+/// shows the tooltip, selection alone drives the highlight.
+fn hunk_marker_glyph_and_fg(
+    state: &DiffViewState,
+    hunk_idx: usize,
+    theme: &Theme,
+) -> (&'static str, Color) {
+    let is_selected = Some(hunk_idx) == state.selected_revert_hunk;
+    let fg = if is_selected {
+        theme.accent
+    } else if state.is_staged_hunk(hunk_idx) {
+        theme.file_staged.fg.unwrap_or(Color::Green)
+    } else {
+        theme.separator
+    };
+    let glyph = if state.is_staged_hunk(hunk_idx) {
+        "✓"
+    } else {
+        "󰧛"
+    };
+    (glyph, fg)
+}
+
 fn render_revert_tooltip(
     buf: &mut Buffer,
     x: u16,
@@ -2282,6 +2433,7 @@ fn render_revert_tooltip(
     max_width: u16,
     theme: &Theme,
     show_key: bool,
+    staged: bool,
 ) {
     let tip_style = Style::default().bg(theme.selected_bg).fg(theme.text_strong);
     let key_style = Style::default()
@@ -2289,14 +2441,15 @@ fn render_revert_tooltip(
         .fg(theme.accent_secondary)
         .add_modifier(Modifier::BOLD);
 
-    let parts: Vec<(&str, Style)> = if show_key {
-        vec![
-            (" ", tip_style),
-            ("enter", key_style),
-            (" Revert hunk ", tip_style),
-        ]
+    let label = if staged {
+        " Staged hunk "
     } else {
-        vec![(" Revert hunk ", tip_style)]
+        " Hunk menu "
+    };
+    let parts: Vec<(&str, Style)> = if show_key {
+        vec![(" ", tip_style), ("enter", key_style), (label, tip_style)]
+    } else {
+        vec![(label, tip_style)]
     };
 
     let buf_area = buf.area();
@@ -3159,6 +3312,37 @@ fn rename_only_lines(old_path: &str, new_path: &str, tab_width: usize) -> Vec<Di
     }]
 }
 
+/// File-relative line spans for one visual change block. `old`/`new` are
+/// the inclusive ranges on each side (`None` for pure insertions/deletions);
+/// `old_point`/`new_point` are the gap positions of those pure blocks so
+/// they can still be matched across diffs that share the side.
+#[derive(Debug, Clone, Copy)]
+pub struct BlockSpan {
+    pub old: Option<(usize, usize)>,
+    pub new: Option<(usize, usize)>,
+    pub old_point: usize,
+    pub new_point: usize,
+}
+
+impl BlockSpan {
+    /// Effective inclusive span on one side, using the gap point for pure
+    /// insertions (`old`) and pure deletions (`new`).
+    pub fn eff(&self, new_side: bool) -> (usize, usize) {
+        if new_side {
+            self.new.unwrap_or((self.new_point, self.new_point))
+        } else {
+            self.old.unwrap_or((self.old_point, self.old_point))
+        }
+    }
+
+    /// True when both spans touch on the given side.
+    pub fn overlaps(&self, other: &BlockSpan, new_side: bool) -> bool {
+        let (lo1, hi1) = self.eff(new_side);
+        let (lo2, hi2) = other.eff(new_side);
+        lo1 <= hi2 && lo2 <= hi1
+    }
+}
+
 /// Parse hunk headers from a unified diff, returning
 /// `(old_start, new_start, old_count, new_count)` for each hunk.
 fn parse_hunk_headers(diff: &str) -> Vec<(usize, usize, usize, usize)> {
@@ -3192,6 +3376,46 @@ fn parse_hunk_headers(diff: &str) -> Vec<(usize, usize, usize, usize)> {
         hunks.push((old_start, new_start, old_count, new_count));
     }
     hunks
+}
+
+/// One `staged` flag per visual change block of a `git diff HEAD` buffer,
+/// in block order. Both diffs share worktree (new-side) numbering, so a
+/// HEAD block that overlaps no unstaged block must be fully staged;
+/// anything touching unstaged work counts as unstaged — including regions
+/// where staged and unstaged edits overlap. Handles multi-file buffers by
+/// matching sections on filename; files missing from the unstaged diff are
+/// fully staged. Falls back to single-diff parsing for header-less input.
+pub fn head_block_staged_flags(
+    head_diff: &str,
+    unstaged_diff: &str,
+    tab_width: usize,
+) -> Vec<bool> {
+    let head_sections = parse_multi_file_diff(head_diff);
+    if head_sections.is_empty() {
+        return head_blocks_staged_flags(head_diff, unstaged_diff, tab_width);
+    }
+    let unstaged_sections = parse_multi_file_diff(unstaged_diff);
+    let mut flags = Vec::new();
+    for (name, body) in &head_sections {
+        let peer = unstaged_sections
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, b)| *b)
+            .unwrap_or("");
+        flags.extend(head_blocks_staged_flags(body, peer, tab_width));
+    }
+    flags
+}
+
+/// One `staged` flag per visual change block of a single-file
+/// `git diff HEAD` buffer.
+fn head_blocks_staged_flags(head_diff: &str, unstaged_diff: &str, tab_width: usize) -> Vec<bool> {
+    let head_spans = DiffViewState::block_spans_for_diff(head_diff, tab_width);
+    let unstaged_spans = DiffViewState::block_spans_for_diff(unstaged_diff, tab_width);
+    head_spans
+        .iter()
+        .map(|h| !unstaged_spans.iter().any(|u| h.overlaps(u, true)))
+        .collect()
 }
 
 /// Build the hunk line offset table from parsed hunk headers and
@@ -3270,6 +3494,62 @@ mod tests {
             file_header: None,
             section_index: 0,
         }
+    }
+
+    #[test]
+    fn head_buffer_classifies_staged_hunks_without_separator() {
+        // Real `git diff HEAD` output: staged edit at line 2, unstaged edit
+        // at line 9, merged into a single `@@` by git. Block-level overlap
+        // still tells them apart.
+        let head = "diff --git a/f.txt b/f.txt\nindex f00c965..edee7ac 100644\n--- a/f.txt\n+++ b/f.txt\n@@ -1,10 +1,10 @@\n 1\n-2\n+TWO\n 3\n 4\n 5\n 6\n 7\n 8\n-9\n+NINE\n 10\n";
+        let unstaged = "diff --git a/f.txt b/f.txt\nindex 9935360..edee7ac 100644\n--- a/f.txt\n+++ b/f.txt\n@@ -6,5 +6,5 @@ TWO\n 6\n 7\n 8\n-9\n+NINE\n 10\n";
+        let parsed = DiffViewState::parse_head_with_staged("f.txt", head, unstaged, 4, true);
+        assert_eq!(parsed.hunk_starts.len(), 2);
+        assert_eq!(parsed.hunk_staged, vec![true, false]);
+        // No separator: a single coherent buffer.
+        assert!(
+            parsed.lines.iter().all(|l| l.file_header.is_none()),
+            "single buffer must not contain section separators"
+        );
+        // The staged hunk keeps its HEAD line numbers.
+        let mut state = DiffViewState::new();
+        state.apply_parsed(parsed);
+        assert_eq!(
+            state.visual_block_line_ranges(0),
+            Some((Some((2, 2)), Some((2, 2))))
+        );
+        assert!(state.is_staged_hunk(0));
+        assert!(!state.is_staged_hunk(1));
+    }
+
+    #[test]
+    fn staged_deletion_classifies_as_staged() {
+        // Staged deletion of line 2; unstaged edit of line 9.
+        let head = "diff --git a/f.txt b/f.txt\n--- a/f.txt\n+++ b/f.txt\n@@ -1,4 +1,3 @@\n 1\n-2\n 3\n 4\n@@ -7,4 +6,4 @@\n 7\n 8\n-9\n+NINE\n";
+        let unstaged = "diff --git a/f.txt b/f.txt\n--- a/f.txt\n+++ b/f.txt\n@@ -5,5 +5,5 @@\n 6\n 7\n 8\n-9\n+NINE\n 10\n";
+        // Note: in worktree coordinates the edit sits at line 8 (line 2 was
+        // already deleted by the staged hunk); the HEAD hunk covers it, so
+        // the second HEAD hunk must still read as unstaged.
+        let parsed = DiffViewState::parse_head_with_staged("f.txt", head, unstaged, 4, true);
+        assert_eq!(parsed.hunk_staged, vec![true, false]);
+        // The deletion-only staged block exposes a worktree gap point, and
+        // the unstaged block overlaps the second HEAD block on that side.
+        let head_spans = DiffViewState::block_spans(&parsed.lines, &parsed.hunk_line_offsets);
+        let unst_spans = DiffViewState::block_spans_for_diff(unstaged, 4);
+        assert_eq!(head_spans.len(), 2);
+        assert_eq!(head_spans[0].new, None);
+        assert!(head_spans[1].overlaps(&unst_spans[0], true));
+        assert!(!head_spans[0].overlaps(&unst_spans[0], true));
+    }
+
+    #[test]
+    fn overlapping_edits_count_as_unstaged() {
+        // Same line edited in index and worktree: HEAD hunk overlaps the
+        // unstaged hunk, so it must not offer Unstage alone.
+        let head = "diff --git a/f.txt b/f.txt\n--- a/f.txt\n+++ b/f.txt\n@@ -1,3 +1,3 @@\n a\n-b\nW\n c\n";
+        let unstaged = "diff --git a/f.txt b/f.txt\n--- a/f.txt\n+++ b/f.txt\n@@ -1,3 +1,3 @@\n a\n-S\nW\n c\n";
+        let parsed = DiffViewState::parse_head_with_staged("f.txt", head, unstaged, 4, true);
+        assert_eq!(parsed.hunk_staged, vec![false]);
     }
 
     #[test]

--- a/src/pager/side_by_side.rs
+++ b/src/pager/side_by_side.rs
@@ -589,135 +589,144 @@ impl DiffViewState {
         }
     }
 
-    /// Parse a `git diff HEAD` buffer for a file that has both staged and
-    /// unstaged changes, classifying each hunk via `unstaged_diff`.
-    ///
-    /// This is a true single buffer: one coherent set of line numbers (no
-    /// separator, no duplicated context). Both diffs share worktree
-    /// (new-side) numbering, so a HEAD hunk that overlaps no unstaged hunk
-    /// must be fully staged; anything touching unstaged work counts as
-    /// unstaged — including regions where staged and unstaged edits overlap.
-    pub fn parse_head_with_staged(
+    /// Parse a single file's unstaged + staged diffs into one scrollable
+    /// buffer: unstaged hunks first, then a `Staged changes` separator and
+    /// the staged hunks. `hunk_staged` records which section each hunk came
+    /// from so the hunk menu can offer Stage vs Unstage per hunk. Either
+    /// side may be empty (all-staged / all-unstaged file); the separator
+    /// only appears when both sides have content.
+    pub fn parse_combined_file_diff(
         filename: &str,
-        head_diff: &str,
         unstaged_diff: &str,
+        staged_diff: &str,
         tab_width: usize,
         file_exists_on_disk: bool,
     ) -> ParsedDiff {
-        let mut parsed =
-            Self::parse_diff_output(filename, head_diff, tab_width, file_exists_on_disk);
-        parsed.hunk_staged = head_block_staged_flags(head_diff, unstaged_diff, tab_width);
-        // Defensive: block classification and the parsed view count blocks
-        // with the same walk, but never let the flags drift out of step.
-        if parsed.hunk_staged.len() != parsed.hunk_starts.len() {
-            parsed.hunk_staged = vec![false; parsed.hunk_starts.len()];
+        let actual_name = parse_multi_file_diff(unstaged_diff)
+            .first()
+            .map(|(name, _)| name.clone())
+            .or_else(|| {
+                parse_multi_file_diff(staged_diff)
+                    .first()
+                    .map(|(name, _)| name.clone())
+            })
+            .unwrap_or_else(|| filename.to_string());
+
+        let (unstaged_old, unstaged_new) = parse_unified_diff(unstaged_diff);
+        let (staged_old, staged_new) = parse_unified_diff(staged_diff);
+
+        let mut lines = diff_lines_from_unified_or_rename_only(unstaged_diff, tab_width);
+        let mut hunk_starts = super::diff_algo::find_hunk_starts(&lines);
+        let mut hunk_staged = vec![false; hunk_starts.len()];
+        let hunks_u = parse_hunk_headers(unstaged_diff);
+        let mut hunk_line_offsets = build_hunk_line_offsets(&hunks_u, &lines, 0);
+        let mut sections = vec![FileSection {
+            old_highlighter: FileHighlighter::new(&unstaged_old, &actual_name),
+            new_highlighter: FileHighlighter::new(&unstaged_new, &actual_name),
+        }];
+
+        if !staged_diff.trim().is_empty() {
+            let mut staged_lines = diff_lines_from_unified_or_rename_only(staged_diff, tab_width);
+            if !staged_lines.is_empty() {
+                if !lines.is_empty() {
+                    lines.push(DiffLine {
+                        old_line: None,
+                        new_line: None,
+                        change_type: ChangeType::Equal,
+                        old_segments: None,
+                        new_segments: None,
+                        file_header: Some("Staged changes".to_string()),
+                        section_index: 1,
+                    });
+                }
+                let section_start = lines.len();
+                for line in &mut staged_lines {
+                    line.section_index = 1;
+                }
+                let staged_starts = super::diff_algo::find_hunk_starts(&staged_lines);
+                for s in staged_starts {
+                    hunk_starts.push(section_start + s);
+                    hunk_staged.push(true);
+                }
+                lines.append(&mut staged_lines);
+                let hunks_s = parse_hunk_headers(staged_diff);
+                let staged_offsets = build_hunk_line_offsets(&hunks_s, &lines[section_start..], 0);
+                for (idx, old_off, new_off) in staged_offsets {
+                    hunk_line_offsets.push((section_start + idx, old_off, new_off));
+                }
+                sections.push(FileSection {
+                    old_highlighter: FileHighlighter::new(&staged_old, &actual_name),
+                    new_highlighter: FileHighlighter::new(&staged_new, &actual_name),
+                });
+            }
         }
-        parsed
+
+        // Left leans HEAD-ish (staged old), right leans worktree
+        // (unstaged new), falling back to whichever side exists.
+        let old_content = if staged_old.is_empty() {
+            unstaged_old
+        } else {
+            staged_old
+        };
+        let new_content = if unstaged_new.is_empty() {
+            staged_new
+        } else {
+            unstaged_new
+        };
+
+        ParsedDiff {
+            filename: actual_name,
+            old_content,
+            new_content,
+            lines,
+            hunk_starts,
+            hunk_staged,
+            hunk_line_offsets,
+            sections,
+            file_exists_on_disk,
+        }
     }
 
-    /// File-relative (old, new) line spans for every visual change block of
-    /// a raw unified diff, without tree-sitter highlighting. Used to map a
-    /// hunk the user acts on in the HEAD buffer onto the matching block(s)
-    /// of the staged/unstaged diff that patch slicing consumes.
-    pub fn block_spans_for_diff(diff_text: &str, tab_width: usize) -> Vec<BlockSpan> {
-        let lines = diff_lines_from_unified_or_rename_only(diff_text, tab_width);
-        let hunks = parse_hunk_headers(diff_text);
-        let file_header_count = lines.iter().take_while(|l| l.file_header.is_some()).count();
-        let offsets = build_hunk_line_offsets(&hunks, &lines, file_header_count);
-        Self::block_spans(&lines, &offsets)
-    }
-
-    /// File-relative spans for visual change blocks from already-parsed
-    /// lines. `old`/`new` are `None` for pure insertions/deletions; the
-    /// `*_point` gap positions still allow matching those blocks across
-    /// diffs that share a side (worktree for unstaged, HEAD for staged).
-    pub fn block_spans(
-        lines: &[DiffLine],
-        hunk_line_offsets: &[(usize, usize, usize)],
-    ) -> Vec<BlockSpan> {
-        let offsets_at = |idx: usize| {
-            let mut offsets = (0usize, 0usize);
-            for &(start_idx, old_off, new_off) in hunk_line_offsets {
-                if start_idx <= idx {
-                    offsets = (old_off, new_off);
-                } else {
-                    break;
-                }
-            }
-            offsets
-        };
-        let file_num = |idx: usize, new_side: bool| -> Option<usize> {
-            let (old_off, new_off) = offsets_at(idx);
-            let line = lines.get(idx)?;
-            if new_side {
-                line.new_line.as_ref().map(|(n, _)| *n + new_off)
-            } else {
-                line.old_line.as_ref().map(|(n, _)| *n + old_off)
-            }
-        };
-
-        let mut spans = Vec::new();
-        let mut start = 0usize;
-        while start < lines.len() {
-            if lines[start].file_header.is_some()
-                || matches!(lines[start].change_type, ChangeType::Equal)
-            {
-                start += 1;
-                continue;
-            }
-            let mut end = start;
-            while end < lines.len()
-                && lines[end].file_header.is_none()
-                && !matches!(lines[end].change_type, ChangeType::Equal)
-            {
-                end += 1;
-            }
-            let mut old_range: Option<(usize, usize)> = None;
-            let mut new_range: Option<(usize, usize)> = None;
-            for idx in start..end {
-                let line = &lines[idx];
-                if matches!(line.change_type, ChangeType::Delete | ChangeType::Modified) {
-                    if let Some(n) = file_num(idx, false) {
-                        old_range = Some(match old_range {
-                            None => (n, n),
-                            Some((lo, hi)) => (lo.min(n), hi.max(n)),
-                        });
-                    }
-                }
-                if matches!(line.change_type, ChangeType::Insert | ChangeType::Modified) {
-                    if let Some(n) = file_num(idx, true) {
-                        new_range = Some(match new_range {
-                            None => (n, n),
-                            Some((lo, hi)) => (lo.min(n), hi.max(n)),
-                        });
-                    }
-                }
-            }
-            // Gap position for pure insertions/deletions: just after the
-            // previous surviving line (0 when the block starts the file).
-            // Both parses of the same edit compute the same point because
-            // they share that side's content.
-            let gap_point = |new_side: bool| -> usize {
-                for idx in (0..start).rev() {
-                    if let Some(n) = file_num(idx, new_side) {
-                        return n + 1;
-                    }
-                }
-                0
-            };
-            spans.push(BlockSpan {
-                old: old_range,
-                new: new_range,
-                old_point: old_range
-                    .map(|(lo, _)| lo)
-                    .unwrap_or_else(|| gap_point(false)),
-                new_point: new_range
-                    .map(|(lo, _)| lo)
-                    .unwrap_or_else(|| gap_point(true)),
-            });
-            start = end;
+    /// Stack two already-parsed diffs (e.g. multi-file directory hovers)
+    /// with a `Staged changes` separator between them. Hunk starts and
+    /// line-offset indices of the second half are rebased past the first
+    /// half + separator, and its section indices are bumped past the
+    /// first half's sections. The separator is omitted when either half
+    /// is empty. Callers set each half's `hunk_staged` before combining.
+    pub fn combine_parsed_with_separator(
+        mut first: ParsedDiff,
+        mut second: ParsedDiff,
+    ) -> ParsedDiff {
+        if second.lines.is_empty() {
+            return first;
         }
-        spans
+        if first.lines.is_empty() {
+            return second;
+        }
+        let section_base = first.sections.len();
+        let base = first.lines.len() + 1;
+        first.lines.push(DiffLine {
+            old_line: None,
+            new_line: None,
+            change_type: ChangeType::Equal,
+            old_segments: None,
+            new_segments: None,
+            file_header: Some("Staged changes".to_string()),
+            section_index: section_base,
+        });
+        for line in &mut second.lines {
+            line.section_index += section_base;
+        }
+        first.lines.append(&mut second.lines);
+        for s in second.hunk_starts {
+            first.hunk_starts.push(base + s);
+        }
+        first.hunk_staged.append(&mut second.hunk_staged);
+        for (idx, old_off, new_off) in second.hunk_line_offsets {
+            first.hunk_line_offsets.push((base + idx, old_off, new_off));
+        }
+        first.sections.append(&mut second.sections);
+        first
     }
 
     /// Parse raw diff output into a ParsedDiff on any thread (no &self needed).
@@ -2402,9 +2411,10 @@ fn unified_line_number_text(num: Option<usize>, chunk_idx: usize) -> String {
     }
 }
 
-/// Glyph + foreground for a hunk marker: blue `󰧛` for the focused
-/// (unstaged) hunk, green `✓` for staged hunks. No hover color — hover only
-/// shows the tooltip, selection alone drives the highlight.
+/// Glyph + foreground for a hunk marker. Sections are split by a
+/// `Staged changes` separator, so every marker uses the same `󰧛` glyph:
+/// blue when focused, dim otherwise. No hover color — hover only shows
+/// the tooltip, selection alone drives the highlight.
 fn hunk_marker_glyph_and_fg(
     state: &DiffViewState,
     hunk_idx: usize,
@@ -2413,17 +2423,10 @@ fn hunk_marker_glyph_and_fg(
     let is_selected = Some(hunk_idx) == state.selected_revert_hunk;
     let fg = if is_selected {
         theme.accent
-    } else if state.is_staged_hunk(hunk_idx) {
-        theme.file_staged.fg.unwrap_or(Color::Green)
     } else {
         theme.separator
     };
-    let glyph = if state.is_staged_hunk(hunk_idx) {
-        "✓"
-    } else {
-        "󰧛"
-    };
-    (glyph, fg)
+    ("󰧛", fg)
 }
 
 fn render_revert_tooltip(
@@ -3312,37 +3315,6 @@ fn rename_only_lines(old_path: &str, new_path: &str, tab_width: usize) -> Vec<Di
     }]
 }
 
-/// File-relative line spans for one visual change block. `old`/`new` are
-/// the inclusive ranges on each side (`None` for pure insertions/deletions);
-/// `old_point`/`new_point` are the gap positions of those pure blocks so
-/// they can still be matched across diffs that share the side.
-#[derive(Debug, Clone, Copy)]
-pub struct BlockSpan {
-    pub old: Option<(usize, usize)>,
-    pub new: Option<(usize, usize)>,
-    pub old_point: usize,
-    pub new_point: usize,
-}
-
-impl BlockSpan {
-    /// Effective inclusive span on one side, using the gap point for pure
-    /// insertions (`old`) and pure deletions (`new`).
-    pub fn eff(&self, new_side: bool) -> (usize, usize) {
-        if new_side {
-            self.new.unwrap_or((self.new_point, self.new_point))
-        } else {
-            self.old.unwrap_or((self.old_point, self.old_point))
-        }
-    }
-
-    /// True when both spans touch on the given side.
-    pub fn overlaps(&self, other: &BlockSpan, new_side: bool) -> bool {
-        let (lo1, hi1) = self.eff(new_side);
-        let (lo2, hi2) = other.eff(new_side);
-        lo1 <= hi2 && lo2 <= hi1
-    }
-}
-
 /// Parse hunk headers from a unified diff, returning
 /// `(old_start, new_start, old_count, new_count)` for each hunk.
 fn parse_hunk_headers(diff: &str) -> Vec<(usize, usize, usize, usize)> {
@@ -3376,46 +3348,6 @@ fn parse_hunk_headers(diff: &str) -> Vec<(usize, usize, usize, usize)> {
         hunks.push((old_start, new_start, old_count, new_count));
     }
     hunks
-}
-
-/// One `staged` flag per visual change block of a `git diff HEAD` buffer,
-/// in block order. Both diffs share worktree (new-side) numbering, so a
-/// HEAD block that overlaps no unstaged block must be fully staged;
-/// anything touching unstaged work counts as unstaged — including regions
-/// where staged and unstaged edits overlap. Handles multi-file buffers by
-/// matching sections on filename; files missing from the unstaged diff are
-/// fully staged. Falls back to single-diff parsing for header-less input.
-pub fn head_block_staged_flags(
-    head_diff: &str,
-    unstaged_diff: &str,
-    tab_width: usize,
-) -> Vec<bool> {
-    let head_sections = parse_multi_file_diff(head_diff);
-    if head_sections.is_empty() {
-        return head_blocks_staged_flags(head_diff, unstaged_diff, tab_width);
-    }
-    let unstaged_sections = parse_multi_file_diff(unstaged_diff);
-    let mut flags = Vec::new();
-    for (name, body) in &head_sections {
-        let peer = unstaged_sections
-            .iter()
-            .find(|(n, _)| n == name)
-            .map(|(_, b)| *b)
-            .unwrap_or("");
-        flags.extend(head_blocks_staged_flags(body, peer, tab_width));
-    }
-    flags
-}
-
-/// One `staged` flag per visual change block of a single-file
-/// `git diff HEAD` buffer.
-fn head_blocks_staged_flags(head_diff: &str, unstaged_diff: &str, tab_width: usize) -> Vec<bool> {
-    let head_spans = DiffViewState::block_spans_for_diff(head_diff, tab_width);
-    let unstaged_spans = DiffViewState::block_spans_for_diff(unstaged_diff, tab_width);
-    head_spans
-        .iter()
-        .map(|h| !unstaged_spans.iter().any(|u| h.overlaps(u, true)))
-        .collect()
 }
 
 /// Build the hunk line offset table from parsed hunk headers and
@@ -3497,59 +3429,77 @@ mod tests {
     }
 
     #[test]
-    fn head_buffer_classifies_staged_hunks_without_separator() {
-        // Real `git diff HEAD` output: staged edit at line 2, unstaged edit
-        // at line 9, merged into a single `@@` by git. Block-level overlap
-        // still tells them apart.
-        let head = "diff --git a/f.txt b/f.txt\nindex f00c965..edee7ac 100644\n--- a/f.txt\n+++ b/f.txt\n@@ -1,10 +1,10 @@\n 1\n-2\n+TWO\n 3\n 4\n 5\n 6\n 7\n 8\n-9\n+NINE\n 10\n";
-        let unstaged = "diff --git a/f.txt b/f.txt\nindex 9935360..edee7ac 100644\n--- a/f.txt\n+++ b/f.txt\n@@ -6,5 +6,5 @@ TWO\n 6\n 7\n 8\n-9\n+NINE\n 10\n";
-        let parsed = DiffViewState::parse_head_with_staged("f.txt", head, unstaged, 4, true);
+    fn combined_file_diff_stacks_sections_with_separator() {
+        let unstaged = "diff --git a/f.txt b/f.txt\n--- a/f.txt\n+++ b/f.txt\n@@ -1,3 +1,3 @@\n a\n-b\n+B\n c\n";
+        let staged = "diff --git a/f.txt b/f.txt\n--- a/f.txt\n+++ b/f.txt\n@@ -5,3 +5,3 @@\n x\n-y\n+Y\n z\n";
+        let parsed = DiffViewState::parse_combined_file_diff("f.txt", unstaged, staged, 4, true);
         assert_eq!(parsed.hunk_starts.len(), 2);
-        assert_eq!(parsed.hunk_staged, vec![true, false]);
-        // No separator: a single coherent buffer.
+        assert_eq!(parsed.hunk_staged, vec![false, true]);
+        // A `Staged changes` separator sits between the two sections.
         assert!(
-            parsed.lines.iter().all(|l| l.file_header.is_none()),
-            "single buffer must not contain section separators"
+            parsed
+                .lines
+                .iter()
+                .any(|l| l.file_header.as_deref() == Some("Staged changes"))
         );
-        // The staged hunk keeps its HEAD line numbers.
+        // Each section keeps its own side's file numbers, which is what
+        // stage/unstage sub-patch slicing consumes directly.
         let mut state = DiffViewState::new();
         state.apply_parsed(parsed);
         assert_eq!(
             state.visual_block_line_ranges(0),
             Some((Some((2, 2)), Some((2, 2))))
         );
-        assert!(state.is_staged_hunk(0));
-        assert!(!state.is_staged_hunk(1));
+        assert_eq!(
+            state.visual_block_line_ranges(1),
+            Some((Some((6, 6)), Some((6, 6))))
+        );
+        assert!(!state.is_staged_hunk(0));
+        assert!(state.is_staged_hunk(1));
     }
 
     #[test]
-    fn staged_deletion_classifies_as_staged() {
-        // Staged deletion of line 2; unstaged edit of line 9.
-        let head = "diff --git a/f.txt b/f.txt\n--- a/f.txt\n+++ b/f.txt\n@@ -1,4 +1,3 @@\n 1\n-2\n 3\n 4\n@@ -7,4 +6,4 @@\n 7\n 8\n-9\n+NINE\n";
-        let unstaged = "diff --git a/f.txt b/f.txt\n--- a/f.txt\n+++ b/f.txt\n@@ -5,5 +5,5 @@\n 6\n 7\n 8\n-9\n+NINE\n 10\n";
-        // Note: in worktree coordinates the edit sits at line 8 (line 2 was
-        // already deleted by the staged hunk); the HEAD hunk covers it, so
-        // the second HEAD hunk must still read as unstaged.
-        let parsed = DiffViewState::parse_head_with_staged("f.txt", head, unstaged, 4, true);
-        assert_eq!(parsed.hunk_staged, vec![true, false]);
-        // The deletion-only staged block exposes a worktree gap point, and
-        // the unstaged block overlaps the second HEAD block on that side.
-        let head_spans = DiffViewState::block_spans(&parsed.lines, &parsed.hunk_line_offsets);
-        let unst_spans = DiffViewState::block_spans_for_diff(unstaged, 4);
-        assert_eq!(head_spans.len(), 2);
-        assert_eq!(head_spans[0].new, None);
-        assert!(head_spans[1].overlaps(&unst_spans[0], true));
-        assert!(!head_spans[0].overlaps(&unst_spans[0], true));
-    }
-
-    #[test]
-    fn overlapping_edits_count_as_unstaged() {
-        // Same line edited in index and worktree: HEAD hunk overlaps the
-        // unstaged hunk, so it must not offer Unstage alone.
-        let head = "diff --git a/f.txt b/f.txt\n--- a/f.txt\n+++ b/f.txt\n@@ -1,3 +1,3 @@\n a\n-b\nW\n c\n";
-        let unstaged = "diff --git a/f.txt b/f.txt\n--- a/f.txt\n+++ b/f.txt\n@@ -1,3 +1,3 @@\n a\n-S\nW\n c\n";
-        let parsed = DiffViewState::parse_head_with_staged("f.txt", head, unstaged, 4, true);
+    fn combined_file_diff_omits_separator_for_single_side() {
+        let unstaged = "diff --git a/f.txt b/f.txt\n--- a/f.txt\n+++ b/f.txt\n@@ -1,3 +1,3 @@\n a\n-b\n+B\n c\n";
+        let parsed = DiffViewState::parse_combined_file_diff("f.txt", unstaged, "", 4, true);
         assert_eq!(parsed.hunk_staged, vec![false]);
+        assert!(parsed.lines.iter().all(|l| l.file_header.is_none()));
+
+        let staged = "diff --git a/f.txt b/f.txt\n--- a/f.txt\n+++ b/f.txt\n@@ -5,3 +5,3 @@\n x\n-y\n+Y\n z\n";
+        let parsed = DiffViewState::parse_combined_file_diff("f.txt", "", staged, 4, true);
+        assert_eq!(parsed.hunk_staged, vec![true]);
+        assert!(parsed.lines.iter().all(|l| l.file_header.is_none()));
+    }
+
+    #[test]
+    fn combine_parsed_with_separator_rebases_second_half() {
+        let a = DiffViewState::parse_diff_output(
+            "dir",
+            "diff --git a/a.txt b/a.txt\n--- a/a.txt\n+++ b/a.txt\n@@ -1,2 +1,2 @@\n a\n-b\n+B\n",
+            4,
+            true,
+        );
+        let b = DiffViewState::parse_diff_output(
+            "dir",
+            "diff --git a/c.txt b/c.txt\n--- a/c.txt\n+++ b/c.txt\n@@ -1,2 +1,2 @@\n x\n-y\n+Y\n",
+            4,
+            true,
+        );
+        assert_eq!(a.hunk_starts.len(), 1);
+        assert_eq!(b.hunk_starts.len(), 1);
+        let mut b = b;
+        b.hunk_staged = vec![true; b.hunk_starts.len()];
+        let combined = DiffViewState::combine_parsed_with_separator(a, b);
+        assert_eq!(combined.hunk_starts.len(), 2);
+        assert_eq!(combined.hunk_staged, vec![false, true]);
+        assert!(
+            combined
+                .lines
+                .iter()
+                .any(|l| l.file_header.as_deref() == Some("Staged changes"))
+        );
+        // The staged hunk moved past the first half + separator.
+        assert!(combined.hunk_starts[1] > combined.hunk_starts[0]);
     }
 
     #[test]


### PR DESCRIPTION
Alternative to #feat/hunk-staging (single HEAD buffer with green ✓ tint).

This variant stacks sections instead: unstaged hunks on top, a `Staged changes` separator, then staged hunks — for both single files and directory hovers. Uniform 󰧛 marker glyph throughout (blue when focused, no green); the separator carries the staged/unstaged meaning.

Per-hunk Hunk menu (Stage `s` / Revert `r` / Unstage `u`), click-to-menu, and cycling behavior are unchanged. Each section keeps its own side's line numbers so patch slicing applies directly without cross-side remapping.